### PR TITLE
Prompt for removal confirmation only when input contains user entered…

### DIFF
--- a/src/Components/Generator/DynamicInputContainer.js
+++ b/src/Components/Generator/DynamicInputContainer.js
@@ -225,16 +225,18 @@ export default class DynamicInputContainer extends preact.Component {
                 return prev;
             });
             this.pushStateUp();
-        } 
+        }
     }
 
     // returns boolean whether the field has value based on its type
     static isFieldEmpty(field_value) {
-        if((typeof field_value == 'string') && (field_value)){
-           return false;  
-        } else if(typeof field_value == 'object') {
+        if (typeof field_value == 'string' && field_value) {
+            return false;
+        } else if (typeof field_value == 'object') {
             for (let [key, value] of Object.entries(field_value)) {
-                if((key != 'primary') && (value)) { return false; }
+                if (key != 'primary' && value) {
+                    return false;
+                }
             }
         }
         return true;

--- a/src/Components/Generator/DynamicInputContainer.js
+++ b/src/Components/Generator/DynamicInputContainer.js
@@ -216,13 +216,28 @@ export default class DynamicInputContainer extends preact.Component {
     }
 
     removeDynamicInput(event) {
-        if (window.confirm(t('confirm-input-remove', 'generator'))) {
+        // prompt only if respective field has value entered while removing
+        const field = event.target.getAttribute('rel');
+        const field_value = this.state.fields[field].value;
+        if (DynamicInputContainer.isFieldEmpty(field_value) || window.confirm(t('confirm-input-remove', 'generator'))) {
             this.setState(prev => {
                 delete prev.fields[event.target.getAttribute('rel')];
                 return prev;
             });
             this.pushStateUp();
+        } 
+    }
+
+    // returns boolean whether the field has value based on its type
+    static isFieldEmpty(field_value) {
+        if((typeof field_value == 'string') && (field_value)){
+           return false;  
+        } else if(typeof field_value == 'object') {
+            for (let [key, value] of Object.entries(field_value)) {
+                if((key != 'primary') && (value)) { return false; }
+            }
         }
+        return true;
     }
 
     getDataArray() {


### PR DESCRIPTION
Current Scenario:  When removing the user-entered data, user is alerted regarding the action even when the input field does not have any data in it.

Fix: During the removal, check has been made whether the user has entered any data in that field and action will be taken based on that. If it contains it will throw alert to confirm else removed without alert.