### PR TITLE
Change request parameters order

### DIFF
--- a/src/Components/Generator/CompanyWidget.js
+++ b/src/Components/Generator/CompanyWidget.js
@@ -15,6 +15,16 @@ export default class CompanyWidget extends preact.Component {
         let content = (
             <div className="company-info-content">
                 <div className="company-info-params">
+                    {this.props.company['address']
+                        ? [
+                              <br />,
+                              <span className="company-info-label">
+                                  <Text id="address" />
+                                  :&nbsp;
+                              </span>,
+                              <span>{this.props.company['address'].split('\n').join(', ')}</span>
+                          ]
+                        : []}
                     {this.props.company['fax']
                         ? [
                               <br />,

--- a/src/Components/Generator/RecipientInput.js
+++ b/src/Components/Generator/RecipientInput.js
@@ -10,15 +10,26 @@ export default class RecipientInput extends preact.Component {
                 <div className="form-group fancy-fg recipient-form" style="margin-top: 17px;">
                     <Text id="recipient-explanation" />
                     <br />
-                    <textarea
-                        id="request-recipient"
-                        className="form-element"
-                        placeholder={t('recipient', 'generator')}
-                        rows="4"
-                        spellCheck="false"
-                        onChange={this.props.onChange}
-                        value={this.props.recipientAddress}
-                    />
+                    {this.props.transportMedium === 'email' ? (
+                        <input
+                            type="email"
+                            id="request-recipient"
+                            className="form-element"
+                            placeholder={t('recipient', 'generator')}
+                            onChange={this.props.onEmailChange}
+                            value={this.props.email}
+                        />
+                    ) : (
+                        <textarea
+                            id="request-recipient"
+                            className="form-element"
+                            placeholder={t('recipient', 'generator')}
+                            rows="4"
+                            spellCheck="false"
+                            onChange={this.props.onAddressChange}
+                            value={this.props.recipientAddress}
+                        />
+                    )}
                     <label className="sr-only" htmlFor="request-recipient">
                         <Text id="recipient" />
                     </label>
@@ -35,6 +46,9 @@ export default class RecipientInput extends preact.Component {
 
     static propTypes = {
         recipientAddress: PropTypes.string,
-        onChange: PropTypes.func.isRequired
+        email: PropTypes.string,
+        transportMedium: PropTypes.oneOf(['fax', 'email', 'letter']).isRequired,
+        onAddressChange: PropTypes.func.isRequired,
+        onEmailChange: PropTypes.func.isRequired
     };
 }

--- a/src/Components/Generator/RequestForm.js
+++ b/src/Components/Generator/RequestForm.js
@@ -170,14 +170,17 @@ export default class RequestForm extends preact.Component {
                                 current={this.props.request_data['type']}
                             />
 
-                            <RecipientInput
-                                onChange={e => this.props.onChange({ recipient_address: e.target.value })}
-                                recipientAddress={this.props.request_data.recipient_address}
-                            />
-
                             <TransportMediumChooser
                                 transportMedium={this.props.request_data.transport_medium}
                                 onChange={this.props.onTransportMediumChange}
+                            />
+
+                            <RecipientInput
+                                onAddressChange={e => this.props.onChange({ recipient_address: e.target.value })}
+                                onEmailChange={e => this.props.onChange({ email: e.target.value })}
+                                transportMedium={this.props.request_data.transport_medium}
+                                recipientAddress={this.props.request_data.recipient_address}
+                                email={this.props.request_data.email}
                             />
 
                             {this.renderFlags()}

--- a/src/Components/RequestGeneratorBuilder.js
+++ b/src/Components/RequestGeneratorBuilder.js
@@ -206,6 +206,7 @@ export default class RequestGeneratorBuilder extends preact.Component {
                 (prev.request.transport_medium === 'fax'
                     ? '\n' + t_r('by-fax', company['request-language'] || LOCALE) + company['fax']
                     : '');
+            prev.request.email = company.email;
 
             const language =
                 !!company['request-language'] && company['request-language'] !== ''

--- a/src/Components/RequestGeneratorBuilder.js
+++ b/src/Components/RequestGeneratorBuilder.js
@@ -488,7 +488,7 @@ export default class RequestGeneratorBuilder extends preact.Component {
                         this.storeRequest();
                         download(
                             medium === 'email'
-                                ? this.letter.toMailtoLink(this.state.suggestion && this.state.suggestion.email)
+                                ? this.letter.toMailtoLink(this.state.request.email)
                                 : this.state.blob_url,
                             this.state.download_filename
                         );

--- a/src/DataType/Request.js
+++ b/src/DataType/Request.js
@@ -51,6 +51,11 @@ export default class Request {
          */
         this.recipient_address = '';
         /**
+         * The email address of the request recipient.
+         * @type {String}
+         */
+        this.email = '';
+        /**
          * The signature to be included after the content in pdfmake format. If not left blank, this can be:
          *     - `{ type: 'text', name: 'Name' }` to just add the name
          *     - `{ type: 'image', name: 'Name', value: 'base64-encoded image' }` to include an image and the name
@@ -147,6 +152,7 @@ export default class Request {
             response_type: response_type,
             slug: slug,
             recipient: this.recipient_address,
+            email: this.email,
             via: this.transport_medium
         };
         new UserRequests().storeRequest(db_id, item);

--- a/src/Utility/request-generator-replacers.js
+++ b/src/Utility/request-generator-replacers.js
@@ -21,7 +21,7 @@ const replacer_factory = that => ({
         <ActionButton
             transport_medium={that.state.request.transport_medium}
             blob_url={that.state.blob_url}
-            mailto_link={that.letter.toMailtoLink((that.state.suggestion && that.state.suggestion.email) || '')}
+            mailto_link={that.letter.toMailtoLink(that.state.request.email)}
             download_filename={that.state.download_filename}
             download_active={that.state.download_active}
             done={that.state.request.done}
@@ -114,8 +114,11 @@ const replacer_factory = that => ({
     ),
     RecipientInputPlaceholder: el => (
         <RecipientInput
-            onChange={e => that.handleInputChange({ recipient_address: e.target.value })}
+            onAddressChange={e => that.handleInputChange({ recipient_address: e.target.value })}
+            onEmailChange={e => that.handleInputChange({ email: e.target.value })}
+            transportMedium={that.state.request.transport_medium}
             recipientAddress={that.state.request.recipient_address}
+            email={that.state.request.email}
             {...el.attributes}
         />
     ),

--- a/src/my-requests.js
+++ b/src/my-requests.js
@@ -308,7 +308,7 @@ class RequestList extends preact.Component {
     }
 
     buildCsv() {
-        let csv = 'date;slug;recipient;reference;type;via\r\n';
+        let csv = 'date;slug;recipient;email;reference;type;via\r\n';
         this.state.sorted_request_ids
             .filter(a => this.state.selected_requests.includes(a))
             .forEach(id => {
@@ -318,6 +318,7 @@ class RequestList extends preact.Component {
                         request.date,
                         request.slug,
                         request.recipient.replace(/[\n\r]+/g, ', '),
+                        request.email,
                         request.reference,
                         request.type,
                         request.via

--- a/src/styles/generator.scss
+++ b/src/styles/generator.scss
@@ -211,3 +211,7 @@ h2 {
     margin-top: 10px;
     margin-bottom: 10px;
 }
+
+.request-transport-medium-chooser {
+    margin-top: 17px;
+}


### PR DESCRIPTION
#82 

![Generate a request · datarequests org](https://user-images.githubusercontent.com/3119252/66713226-7a58df00-ed97-11e9-86f1-e1724e6813a2.png)

- Change the order of transport medium and recipient address
- Display email address in input when transport medium is "Email"
- Add company's physical address (comma separated) to the company widget

Let me know if I overlooked or missed out something.