### PR TITLE
Automatically crop the signature

### DIFF
--- a/src/Components/Generator/SignatureInput.js
+++ b/src/Components/Generator/SignatureInput.js
@@ -72,7 +72,15 @@ export default class SignatureInput extends preact.Component {
                 const top = (this.canvas.height - img.height) / 2;
                 this.clear();
                 this.context.drawImage(img, left, top);
-                this.setState({ isEmpty: false });
+                this.setState({
+                    isEmpty: false,
+                    cropArea: {
+                        top,
+                        bottom: img.height + top,
+                        left,
+                        right: img.width + left
+                    }
+                });
                 this.handleChange();
             };
             img.src = signature.value;
@@ -101,8 +109,7 @@ export default class SignatureInput extends preact.Component {
     clear() {
         if (this.state.isEmpty) return;
         this.context.clearRect(0, 0, this.state.width, this.state.height);
-        this.setState({ isEmpty: true });
-        this.setState({ cropArea: this.initialCropArea });
+        this.setState({ isEmpty: true, cropArea: this.initialCropArea });
         this.handleChange();
     }
 


### PR DESCRIPTION
Should solve [this](https://github.com/datenanfragen/website/issues/91) issue... eventually.

For now I've figured out how to crop the canvas (thanks to stack overflow) and also figured out that it conflicts a bit with detectBlockedCanvasImageExtraction (which does not restore the original pixel color (at least for me in chrome)).

I store the result in `croppedValue` property on signature object since original `value` property is still used to store canvas state.

What I still have troubles with is getting the croppedValue to render in pdf instead of value; would be grateful for any pointers. 