### PR TITLE
Actually restore the old pixel in detectBlockedCanvasImageExtraction

### DIFF
--- a/src/Utility/browser.js
+++ b/src/Utility/browser.js
@@ -5,29 +5,45 @@ export function clearUrlParameters() {
     for (const p in PARAMETERS) if (Object.prototype.hasOwnProperty.call(PARAMETERS, p)) delete PARAMETERS[p];
 }
 
-// Returns `true` if canvas image extraction is blocked.
-// Inspired by: https://estada.ch/2018/12/22/firefox-privacy-enhancement-renders-every-off-screen-canvas-white/
+/**
+ * Check whether canvas image extraction is blocked (usually because the user is either the Tor Browser or has
+ * `privacy.resistFingerprinting` turned on in Firefox).
+ *
+ * If the extraction is in fact blocked, the browser will return white for any pixel of the canvas. We can use this to
+ * do a little experiment: We paint one pixel of the canvas in any color and then try to extract the value. If it white,
+ * extraction is blocked, otherwise it is not.
+ * Inspired by: https://estada.ch/2018/12/22/firefox-privacy-enhancement-renders-every-off-screen-canvas-white/
+ *
+ * @param {CanvasRenderingContext2D} [ctx] A canvas context if we already have one. Otherwise, we will just create one
+ *     on the fly.
+ * @returns {boolean} true if canvas extraction is blocked, false otherwise
+ */
 export function detectBlockedCanvasImageExtraction(ctx = undefined) {
     if (!ctx) {
         const c = document.createElement('canvas');
         c.width = c.height = 1;
         ctx = c.getContext('2d');
     }
+    // For the test, we need to set the `fillStyle`. As this setting is persisted for the context (which may be used
+    // elsewhere), we need to remember the old value.
     const old_fs = ctx.fillStyle;
+    // We also need to remember the previous data at the pixel we will override. To make sure we don't run into any
+    // compression issues, we remember a little more than a single pixel.
+    const old_data = ctx.getImageData(0, 0, 5, 5);
 
-    const old_px = ctx.getImageData(0, 0, 1, 1).data;
-    // I unfortunately can't seem to find a way to set the `fillStyle` to a value I can access directly. :(
-    const old_px_color = ((old_px[0] << 16) | (old_px[1] << 8) | old_px[2]).toString(16);
-
+    // Paint a single pixel at (0, 0) and immediately try to extract it back.
+    // If canvas extraction is blocked, it will return white for any pixel, so we need to choose any color other than
+    // white for this experiment. A nice pink should do the trick.
+    ctx.fillStyle = '#d53f8c';
     ctx.fillRect(0, 0, 1, 1);
     const px = ctx.getImageData(0, 0, 1, 1).data;
 
     // Restore the original pixel. This obviously won't work if extraction is actually blocked but in that case it
     // doesn't matter anyway.
-    ctx.fillStyle = old_px_color;
-    ctx.fillRect(0, 0, 1, 1);
+    ctx.putImageData(old_data, 0, 0);
     ctx.fillStyle = old_fs;
 
+    // Check if the tested pixel is white (i.e. all channels are 255)—in that case extraction is blocked.
     return px.reduce((acc, cur) => acc && cur === 255, true);
 }
 


### PR DESCRIPTION
Problem noticed in #135.

Also be a little more verbose (*too* verbose if you ask me) with comments
as @zner0L was complaining…