### PR TITLE
Fix ScrollSpy highlight

### DIFF
--- a/src/company-list.js
+++ b/src/company-list.js
@@ -79,7 +79,7 @@ class CompanyList extends preact.Component {
                                 items={anchor_ids}
                                 currentClassName="active"
                                 className="textscroll"
-                                offset={-205}>
+                                offset={-280}>
                                 {anchor_links}
                             </Scrollspy>
                         </div>


### PR DESCRIPTION
I noticed when clicking the alphabet, the page scrolls to the correct position in the list but the highlight is the previous alphabet. I've changed the offset to fix the highlight.