### PR TITLE
Closes #211: Fix thanks page URLs

### DIFF
--- a/content/donate.de.md
+++ b/content/donate.de.md
@@ -1,8 +1,7 @@
 {
     "title": "Spenden",
     "type": "donate",
-    "slug": "spenden",
-    "aliases": ["donate", "verein/spenden", "verein/donate"]
+    "aliases": ["spenden", "verein/spenden", "verein/donate"]
 }
 
 Vielen Dank, dass Du daran interessiert bist uns zu unterstützen! Deine Spende hilft uns dabei, unsere aktuellen und kommenden Projekte zu finanzieren, damit sie für alle kostenlos bleiben können.

--- a/content/thanks.de.md
+++ b/content/thanks.de.md
@@ -1,6 +1,7 @@
 {
     "title": "Danke für Deine Spende!",
-    "type": "thanks"
+    "type": "thanks",
+    "aliases": ["verein/thanks", "danke", "verein/danke"]
 }
 
 <img class="top-right-humaaan" src="/img/humaaans/thanks.svg">

--- a/content/thanks.en.md
+++ b/content/thanks.en.md
@@ -1,6 +1,7 @@
 {
     "title": "Thank you for your donation!",
-    "type": "thanks"
+    "type": "thanks",
+    "aliases": ["verein/thanks"]
 }
 
 <img class="top-right-humaaan" src="/img/humaaans/thanks.svg">

--- a/src/Components/DonationWidget.js
+++ b/src/Components/DonationWidget.js
@@ -45,7 +45,7 @@ export default class DonationWidget extends preact.Component {
 
                 switch (response.status) {
                     case 'paid':
-                        window.location = `${BASE_URL}thanks?donation_reference${response.reference}`;
+                        window.location = `${BASE_URL}thanks?donation_reference=${response.reference}`;
                         break;
                     case 'failed':
                         flash(
@@ -229,7 +229,7 @@ export default class DonationWidget extends preact.Component {
                     id="donation-widget-thanks-button"
                     className="button button-primary"
                     style="float: right;"
-                    href={`${BASE_URL}verein/thanks?donation_reference=${this.state.donation_reference}`}>
+                    href={`${BASE_URL}thanks?donation_reference=${this.state.donation_reference}`}>
                     <Text id="thanks" />
                 </a>
                 <div className="clearfix"></div>
@@ -304,7 +304,7 @@ export default class DonationWidget extends preact.Component {
                     business: 'paypal@datenanfragen.de',
                     image_url: 'https://www.datenanfragen.de/img/logo-datenanfragen-ev.png',
                     no_shipping: 1,
-                    return: `${BASE_URL}verein/thanks?donation_reference=${this.state.donation_reference}`,
+                    return: `${BASE_URL}thanks?donation_reference=${this.state.donation_reference}`,
                     cancel_return: `${BASE_URL}donate`,
                     custom: this.state.donation_reference
                 },


### PR DESCRIPTION
Since the donation page is not under the `/verein` prefix, it doesn't
make sense to have the thanks page there.