### PR TITLE
Update "Open Source" page French translation

### DIFF
--- a/content/open-source.fr.md
+++ b/content/open-source.fr.md
@@ -2,7 +2,7 @@
 	"title": "Open Source",
 	"type": "page",
 	"aliases": ["opensource", "oss", "foss"],
-	"heading": "<span style='text-align: center; font-family: monospace;'>demandetesdonnees.org <span class='color-red-600' title='aime'>❤</span>l'Open Source</span>"
+	"heading": "<span style='text-align: center; font-family: monospace;'>demandetesdonnees.fr <span class='color-red-600' title='aime'>❤</span>l'Open Source</span>"
 }
 
 <img id="open-source-humaaan" class="top-left-humaaan" style="margin-top: -70px;" src="/img/humaaans/open-source.svg">

--- a/content/open-source.fr.md
+++ b/content/open-source.fr.md
@@ -2,7 +2,7 @@
 	"title": "Open Source",
 	"type": "page",
 	"aliases": ["opensource", "oss", "foss"],
-	"heading": "<span style='text-align: center; font-family: monospace;'>demandetesdonnees.org <span class='color-red-600' title='loves'>❤</span> Open Source</span>"
+	"heading": "<span style='text-align: center; font-family: monospace;'>demandetesdonnees.org <span class='color-red-600' title='aime'>❤</span>l'Open Source</span>"
 }
 
 <img id="open-source-humaaan" class="top-left-humaaan" style="margin-top: -70px;" src="/img/humaaans/open-source.svg">

--- a/content/open-source.fr.md
+++ b/content/open-source.fr.md
@@ -2,12 +2,100 @@
 	"title": "Open Source",
 	"type": "page",
 	"aliases": ["opensource", "oss", "foss"],
-	"heading": "<span style='text-align: center; font-family: monospace;'>demandetesdonnees.fr <span class='color-red-600' title='liebt'>❤</span> Open Source</span>"
+	"heading": "<span style='text-align: center; font-family: monospace;'>demandetesdonnees.org <span class='color-red-600' title='loves'>❤</span> Open Source</span>"
 }
 
-<!-- TODO: Translate. -->
+<img id="open-source-humaaan" class="top-left-humaaan" style="margin-top: -70px;" src="/img/humaaans/open-source.svg">
+
+L'Open Source est au cœur même de demandetesdonnees.fr. Nous avons conçu le projet à partir de rien pour qu'il soit le plus ouvert possible. Notre [constitution] (https://www.datarequests.org/verein/constitution/) nous engage à publier notre contenu sous licence libre.
+
+Nous sommes de grands partisans de l'Open Source et nous y croyons.
+
+## Nos dépôts Open Source
+
+Voici un aperçu des principaux dépôts que nous avons créés directement ou indirectement, pour demandetesdonnees.fr. Ils sont bien sûr publiés sous licence libre. Nous vous invitons à jeter un coup d'œil derrière le rideau, à contribuer ou à utiliser notre travail pour vos propres projets !
+
+Une partie du travail de développement est actuellement effectuée sur une instance privée de GitLab. Cependant, nous reflétons tous les commits sur GitHub et nous accueillons toujours les issues et les pull requests sur les dépôts de miroirs sur GitHub, évidemment.
+
+<!-- TODO: Add new repos when applicable. -->
+
+<article class="list-article icon-list-article">
+    <div class="col25 article-featured-image"><a href="https://github.com/datenanfragen/website"><img class="image" src="/card-icons/code.svg" alt="website"></a></div>
+    <div class="padded col75">
+        <a href="https://github.com/datenanfragen/website"><h1><code>website</code></h1></a>
+        <span class="license">Licence MIT</span>
+        <p class="description">
+            Le site Web sur lequel tu te trouves actuellement. Ce dépôt contient non seulement le contenu mais aussi le code du générateur, les contrôles de confidentialité et plus encore.
+            <br>Le site est conçu pour être essentiellement statique et fonctionne avec Hugo et Preact.
+        </p>
+        <p class="description">
+            Le site web de Datenanfragen.de e.&nbsp;V., l'association à but non lucratif à l'origine de ce projet, est géré par le dépôt séparé <a href="https://github.com/datenanfragen/verein-website"><code>verein-website</code></a>.
+        </p>
+    </div>
+    <div class="clearfix"></div>
+    <a class="button button-primary read-more-button" href="https://github.com/datenanfragen/website">Voir le dépôt&nbsp;<span class="icon icon-arrow-right"></span></a>
+</article>
+
+<article class="list-article icon-list-article">
+    <div class="col25 article-featured-image"><a href="https://github.com/datenanfragen/data"><img class="image" src="/card-icons/database.svg" alt="data" style="width: 70%;"></a></div>
+    <div class="padded col75">
+        <a href="https://github.com/datenanfragen/data"><h1><code>data</code></h1></a>
+        <span class="license">Licence CC0</span>
+        <p class="description">
+            Les données à l'origine du projet. Il s'agit notamment de nos bases de données sur les entreprises et les autorités de contrôle, mais aussi de nos modèles de lettres.
+            <br>Le dépôt est structuré comme une collection de fichiers de texte brut lisibles par l'homme et par la machine.
+        </p>
+    </div>
+    <div class="clearfix"></div>
+    <a class="button button-primary read-more-button" href="https://github.com/datenanfragen/data">Voir le dépôt&nbsp;<span class="icon icon-arrow-right"></span></a>
+</article>
+
+<article class="list-article icon-list-article">
+    <div class="col25 article-featured-image"><a href="https://github.com/datenanfragen/verein"><img class="image" src="/card-icons/group.svg" alt="verein"></a></div>
+    <div class="padded col75">
+        <a href="https://github.com/datenanfragen/verein"><h1><code>verein</code></h1></a>
+        <p class="description">
+            Nous voulons également gérer l'association à but non lucratif à l'origine de ce projet, Datenanfragen.de e.&nbsp;V., de la manière la plus ouverte et la plus transparente possible. Ainsi, ce dépôt contient des documents importants avec leur historique de modifications.
+        </p>
+    </div>
+    <div class="clearfix"></div>
+    <a class="button button-primary read-more-button" href="https://github.com/datenanfragen/verein">Voir le dépôt&nbsp;<span class="icon icon-arrow-right"></span></a>
+</article>
+
+<article class="list-article icon-list-article">
+    <div class="col25 article-featured-image"><a href="https://github.com/zner0L/postcss-fonticons"><img class="image" src="/card-icons/icon-font.svg" alt="postcss-fonticons" style="width: 60%;"></a></div>
+    <div class="padded col75">
+        <a href="https://github.com/zner0L/postcss-fonticons"><h1><code>postcss-fonticons</code></h1></a>
+        <span class="license">Licence MIT</span>
+        <p class="description">
+            Un plugin PostCSS qui permet de créer une police d'icônes à la volée, en n'incluant que les icônes réellement utilisées.
+            <br>Adapté d'après le <a href="https://github.com/jantimon/iconfont-webpack-plugin">plugin Webpack de police d'icônes</a> de Jan Nicklas.
+        </p>
+    </div>
+    <div class="clearfix"></div>
+    <a class="button button-primary read-more-button" href="https://github.com/zner0L/postcss-fonticons">Voir le dépôt&nbsp;<span class="icon icon-arrow-right"></span></a>
+</article>
+
+<article class="list-article icon-list-article">
+    <div class="col25 article-featured-image"><a href="https://github.com/baltpeter/yace"><img class="image" src="/card-icons/speech-bubble.svg" alt="yace"></a></div>
+    <div class="padded col75">
+        <a href="https://github.com/baltpeter/yace"><h1><code>yace</code></h1></a>
+        <span class="license">Licence MIT</span>
+        <p class="description">
+            Un moteur simple, respectueux de la vie privée et facile à déployer pour créer des solutions de commentaires personnalisées, hébergé sur AWS.
+        </p>
+    </div>
+    <div class="clearfix"></div>
+    <a class="button button-primary read-more-button" href="https://github.com/baltpeter/yace">Voir le dépôt&nbsp;<span class="icon icon-arrow-right"></span></a>
+</article>
 
 <a id="license-notices"></a>
+## Projets Open Source que nous utilisons
+
+En accord avec l'esprit de l'Open Source, nous ne nous contentons pas de maintenir nos propres projets Open Source, mais nous faisons aussi un usage intensif des projets des autres pour notre développement.
+
+Nous sommes fiers de pouvoir utiliser les projets suivants pour ce site Web. Un grand merci aux auteurs qui ont décidé de permettre à d'autres d'utiliser leur précieux travail !
+
 Tu peux trouver les notices de licence complètes pour tous les projets que nous utilisons [ici]({{< absURL "NOTICES.txt" >}}).
 
 <div class="box box-info">

--- a/content/open-source.fr.md
+++ b/content/open-source.fr.md
@@ -13,9 +13,7 @@ Nous sommes de grands partisans de l'Open Source et nous y croyons.
 
 ## Nos dépôts Open Source
 
-Voici un aperçu des principaux dépôts que nous avons créés directement ou indirectement, pour demandetesdonnees.fr. Ils sont bien sûr publiés sous licence libre. Nous vous invitons à jeter un coup d'œil derrière le rideau, à contribuer ou à utiliser notre travail pour vos propres projets !
-
-Une partie du travail de développement est actuellement effectuée sur une instance privée de GitLab. Cependant, nous reflétons tous les commits sur GitHub et nous accueillons toujours les issues et les pull requests sur les dépôts de miroirs sur GitHub, évidemment.
+Voici un aperçu des principaux dépôts que nous avons créés directement ou indirectement, pour demandetesdonnees.fr. Ils sont bien sûr publiés sous licence libre. Nous vous invitons à jeter un coup d'œil derrière le rideau, à contribuer ou à utiliser notre travail pour vos propres projets ! Nous accueillons chaleureusement les issues et les pull requests sur les dépôts de miroirs sur GitHub, évidemment.
 
 <!-- TODO: Add new repos when applicable. -->
 
@@ -27,9 +25,6 @@ Une partie du travail de développement est actuellement effectuée sur une inst
         <p class="description">
             Le site Web sur lequel tu te trouves actuellement. Ce dépôt contient non seulement le contenu mais aussi le code du générateur, les contrôles de confidentialité et plus encore.
             <br>Le site est conçu pour être essentiellement statique et fonctionne avec Hugo et Preact.
-        </p>
-        <p class="description">
-            Le site web de Datenanfragen.de e.&nbsp;V., l'association à but non lucratif à l'origine de ce projet, est géré par le dépôt séparé <a href="https://github.com/datenanfragen/verein-website"><code>verein-website</code></a>.
         </p>
     </div>
     <div class="clearfix"></div>

--- a/content/open-source.fr.md
+++ b/content/open-source.fr.md
@@ -7,7 +7,7 @@
 
 <img id="open-source-humaaan" class="top-left-humaaan" style="margin-top: -70px;" src="/img/humaaans/open-source.svg">
 
-L'Open Source est au cœur même de demandetesdonnees.fr. Nous avons conçu le projet à partir de rien pour qu'il soit le plus ouvert possible. Notre [constitution] (https://www.datarequests.org/verein/constitution/) nous engage à publier notre contenu sous licence libre.
+L'Open Source est au cœur même de demandetesdonnees.fr. Nous avons conçu le projet à partir de rien pour qu'il soit le plus ouvert possible. Notre [constitution](https://www.datarequests.org/verein/constitution/) nous engage à publier notre contenu sous licence libre.
 
 Nous sommes de grands partisans de l'Open Source et nous y croyons.
 


### PR DESCRIPTION
As the page was updated I added and translated the missing content.
I was wondering. As the `verein-website` repository has been merged into `website`. Should this be removed from this page?