### PR TITLE
Fix text overflowing in mobile browsers

### DIFF
--- a/content/de/contribute.md
+++ b/content/de/contribute.md
@@ -12,7 +12,7 @@ Vielen Dank, dass Du Dich über die Möglichkeiten zum Mitmachen informierst!
 <article id="cdb" class="list-article icon-list-article">
     <div class="col25 article-featured-image"><img class="image" src="/card-icons/company.svg" alt="Wartung der Unternehmensdatenbank"></div>
     <div class="padded col75">
-        <h1>Wartung der Unternehmensdatenbank</h1>
+        <h1>Wartung der Un&shy;ter&shy;neh&shy;mens&shy;da&shy;ten&shy;bank</h1>
         <p>Ein zentrales Element von Datenanfragen.de ist unsere <a href="/company">Unternehmensdatenbank</a>. Hier finden sich die Kontaktdaten von zahlreichen Unternehmen und sonstigen Organisationen für Fragen zum Datenschutz.</p>
         <p>So eine Datenbank erfordert natürlich auch eine Menge Wartung, bei der wir Deine Hilfe gebrauchen können! Wenn Du ein Unternehmen entdeckst, das noch nicht vorhanden ist, kannst Du es über den Knopf unten einfach selbst eintragen.
         <br>Bei einem bereits vorhandenen Unternehmen stimmt etwas nicht mehr oder eine Information fehlt? Auf der Detailseite jedes Unternehmens findest Du oben den Button „Änderung vorschlagen“, über den Du die entsprechenden Daten bearbeiten kannst.</p>

--- a/content/de/open-source.md
+++ b/content/de/open-source.md
@@ -103,6 +103,6 @@ Wir sind stolz, die folgenden Projekte für die Webseite verwenden zu dürfen. H
 
 Die vollständigen Lizenzinformationen für alle Projekte, die wir nutzen, findest Du [hier]({{< absURL "NOTICES.txt" >}}).
 
-<div class="box box-info">
+<div class="box box-info attribution-box">
     {{< attribution "von" >}}
 </div>

--- a/content/en/open-source.md
+++ b/content/en/open-source.md
@@ -102,6 +102,6 @@ We are proud to be able to use the following projects for this website. Huge tha
 
 You may find the full license notices for all projects we use [here]({{< absURL "NOTICES.txt" >}}).
 
-<div class="box box-info">
+<div class="box box-info attribution-box">
 	{{< attribution "by" >}}
 </div>

--- a/content/fr/open-source.md
+++ b/content/fr/open-source.md
@@ -102,6 +102,6 @@ Nous sommes fiers de pouvoir utiliser les projets suivants pour ce site Web. Un 
 
 Tu peux trouver les notices de licence complètes pour tous les projets que nous utilisons [ici]({{< absURL "NOTICES.txt" >}}).
 
-<div class="box box-info">
+<div class="box box-info attribution-box">
 	{{< attribution "de" >}}
 </div>

--- a/content/pt/open-source.md
+++ b/content/pt/open-source.md
@@ -12,6 +12,6 @@
 
 A informação completa da licença para todos os projetos que usamos pode ser encontrada [aqui]({{< absURL "NOTICES.txt" >}}).
 
-<div class="box box-info">
+<div class="box box-info attribution-box">
     {{< attribution "por" >}}
 </div>

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -346,6 +346,11 @@ a #logo {
     }
 }
 
+/* Open Source page */
+.attribution-box {
+    word-break: break-all;
+}
+
 /* Wizard */
 #wizard-tabs {
     $tab-border: 4px;


### PR DESCRIPTION
Mobile browsers don't seem to really support hyphenation unfortunately, which caused overflowing text. To avoid that, we now at least break the words on those platforms.

To test this: Check the German contribute page in a mobile browser.