### PR TITLE
Don't use &thinsp; in donation details

### DIFF
--- a/src/Components/DonationWidget.js
+++ b/src/Components/DonationWidget.js
@@ -165,7 +165,7 @@ export default class DonationWidget extends preact.Component {
                         <td>
                             <Text id="bank-transfer-recipient" />
                         </td>
-                        <td>Datenanfragen.de e.&thinsp;V.</td>
+                        <td>Datenanfragen.de e. V.</td>
                     </tr>
                     <tr>
                         <td>IBAN</td>


### PR DESCRIPTION
Unsurprisingly, banks are not too thrilled if you copy this into their forms…