### PR TITLE
Optimize Netlify deploys

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -6,17 +6,6 @@ preserveTaxonomyNames = true
     name = "Datenanfragen.de e. V."
     email = "kontakt@datenanfragen.de"
 
-[related]
-    threshold = 100
-    includeNewer = true
-    toLower = true
-[[related.indices]]
-    name = "categories"
-    weight = 40
-[[related.indices]]
-    name = "relevant-countries"
-    weight = 40
-
 [markup]
   [markup.goldmark]
     [markup.goldmark.renderer]

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,8 +9,8 @@ git clone --depth 1 https://github.com/datenanfragen/data data_tmp
 echo "Creating directories…"
 for lang in ${languages[@]}
 do
-mkdir -p "content/$lang/company"
-mkdir -p "content/$lang/supervisory-authority"
+    mkdir -p "content/$lang/company"
+    mkdir -p "content/$lang/supervisory-authority"
 done
 
 mkdir -p static/templates
@@ -25,8 +25,8 @@ cp data_tmp/supervisory-authorities/* static/db/sva
 
 for lang in ${languages[@]}
 do
-cp data_tmp/companies/* "content/$lang/company"
-cp data_tmp/supervisory-authorities/* "content/$lang/supervisory-authority"
+    cp data_tmp/companies/* "content/$lang/company"
+    cp data_tmp/supervisory-authorities/* "content/$lang/supervisory-authority"
 done
 
 cp -r data_tmp/templates/* static/templates
@@ -44,8 +44,8 @@ echo "Renaming JSON files…"
 
 for lang in ${languages[@]}
 do
-	find "$lang/company" -name '*.json' -exec sh -c 'mv "$0" "${0%.json}.md"' {} \;
-	find "$lang/supervisory-authority" -name '*.json' -exec sh -c 'mv "$0" "${0%.json}.md"' {} \;
+    find "$lang/company" -name '*.json' -exec sh -c 'mv "$0" "${0%.json}.md"' {} \;
+    find "$lang/supervisory-authority" -name '*.json' -exec sh -c 'mv "$0" "${0%.json}.md"' {} \;
 done
 
 cd .. || exit
@@ -57,10 +57,10 @@ yarn run build
 
 if [ "$CONTEXT" = "production" ]
 then
-	hugo -e production --minify
-	echo "Copying files for Netlify…"
-	cp _redirects public/_redirects
-	cp static/404.html public/404.html
+    hugo -e production --minify
+    echo "Copying files for Netlify…"
+    cp _redirects public/_redirects
+    cp static/404.html public/404.html
 else
-	hugo -e staging --baseURL "$DEPLOY_PRIME_URL" --minify
+    hugo -e staging --baseURL "$DEPLOY_PRIME_URL" --minify
 fi

--- a/layouts/company/single.html
+++ b/layouts/company/single.html
@@ -102,20 +102,33 @@
         {{ T "cdb-help-needed" (dict "editUrl" (print ("suggest" | absURL) "?type=edit&for=cdb&slug=" .Params.slug) "newUrl" (print ("suggest" | absURL) "?type=new&for=cdb")) | safeHTML }}
     </div>
 
-    <!-- TODO: This is currently a very naive approach, mostly since we don't exactly have any data to do this better. We will want to improve this in the future. Oh yeah, and this feature seems to be very 'non-deterministic', at least under our parameters. Not sure if that is a good or a bad thing. -->
+    <!-- TODO: This is currently a very naive approach, mostly since we don't exactly have any data to do this better. We will want to improve this in the future. -->
     {{ if not .Site.Params.devMode }}
-    {{ $related := (where (.Site.RegularPages.Related .) "Type" "company") | first 5 }}
-    {{ with $related }}
-    <div id="related-companies">
-        <h2>{{ T "cdb-related-companies" }}</h2>
-        <!-- TODO: Nicer styling -->
-        <ul>
-            {{ range . }}
-            <li><a href="{{ .Permalink }}">{{ .Param "name" }}</a></li>
+        {{ $related_pages := slice }}
+
+        {{ $num_categories := (cond (isset .Params "categories") .Params.categories slice) | len }}
+        {{ $num_countries := (.Param "relevant-countries") | len }}
+
+        {{ range (where .Site.Pages "Section" "company") }}
+            {{ $num_common_categories := intersect $.Params.categories .Params.categories | len }}
+            {{ $num_common_countries := intersect ($.Param "relevant-countries") (.Param "relevant-countries") | len }}
+            {{ if and (gt $num_common_categories 0) (ne .Permalink $.Permalink) }}
+                {{ $score := add (div (float $num_common_categories) $num_categories) (div $num_common_countries $num_countries) }}
+                {{ $related_pages = $related_pages | append (dict "page" . "score" $score) }}
             {{ end }}
-        </ul>
-    </div>
-    {{ end }}
+        {{ end }}
+        {{ $related_pages = sort $related_pages "score" "desc" }}
+        {{ with $related_pages }}
+            <div id="related-companies">
+                <h2>{{ T "cdb-related-companies" }}</h2>
+                <!-- TODO: Nicer styling -->
+                <ul>
+                    {{ range (. | first 5) }}
+                        <li><a href="{{ .page.Permalink }}">{{ .page.Params.name }}</a></li>
+                    {{ end }}
+                </ul>
+            </div>
+        {{ end }}
     {{ end }}
 
     <div id="comments-widget" data-rating-enabled="1" data-display-warning="1"></div>


### PR DESCRIPTION
Recently, I saw [this post](https://community.netlify.com/t/support-guide-making-the-most-of-netlifys-cdn-cache/127) on the Netlify forums, explaining common problems with large sites causing long deploy times. And if we look at [two](https://app.netlify.com/sites/datenanfragen/deploys/5ec2bb3119ca5700074682b7) [recent](https://app.netlify.com/sites/datenanfragen/deploys/5ec2bbb6ea97040006b95cee) deploys, we see this exact phenomenon on our site: More than 5000 changed files have to be uploaded with each deploy.

That is clearly not a result of the [actual changes](https://github.com/datenanfragen/website/commit/d0928da2ce45d16311fd94211576271b75424297) between these two commits. Luckily, Netlify allows us to download the build results (takes a while though and sometimes needs a couple of tries). If we throw those into a directory diff tool, the problem quickly becomes apparent:

![image](https://user-images.githubusercontent.com/4048809/82943057-7e351c80-9f88-11ea-93ab-f5d7dbeb3000.png)

As I [already noted](https://github.com/datenanfragen/website/blob/2130c1bdcdd3a4f994b2c0c0add3da93a73237d1/layouts/company/single.html#L105) when introducing the related companies feature, the related pages Hugo generates are not deterministic at all. They change with every build, causing every entry in the company database to have a different hash each time.

This PR replaces the Hugo implementation with our own one. Unfortunately, this means the full Hugo build takes a fair bit longer. On my machine, running `hugo -e production --minify` takes:

* without related pages: `2748 ms`
* with the previous implementation: `3713 ms`
* with a one-line intersect: `7822 ms`  
  (`{{ $related := (where .Site.Pages ".Params.categories" "intersect" .Params.categories) | intersect (where .Site.Pages ".Params.relevant-countries" "intersect" (.Param "relevant-countries")) | first 5 }}`)
* with the more complex intersect loop and scoring: `18043 ms`

However, these build times are not really relevant as we have disabled the related companies calculation for local devs builds anyway, so we won't notice them on our machines. I am also fairly confident that the extra 10 seconds will be worth it in CI envs as currently on Netlify the actual build takes about 7 minutes while deploying and processing takes 14 minutes.

---

Note: This PR doesn't address another, analogous problem: We are using absolute URLs in our builds. That means that despite the changes in this PR, deploy previews will still cause huge diffs, at least on the first build. Subsequent builds should be faster.  
I don't believe it is worth it to change that, though. Especially since this doesn't affect production builds.