### PR TITLE
Fix banner images

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Benjamin Altpeter
 Lars
 Lewin Sieben
 Lorenz Sieben
+Martin Rey
 Nadja Rode
 Nathan Bonnemains
 Nishant Mittal

--- a/content/de/act/ada-health/index.md
+++ b/content/de/act/ada-health/index.md
@@ -10,7 +10,7 @@
 
 Die App *Ada Health* stellt sich auf ihrer [Webseite](https://ada.com/de/) als „Deine Gesundheitshelferin” vor. Per interaktivem Chat können Nutzer_innen der App die Symptome ihrer Krankheiten mitteilen, welche diese dann verwendet um mögliche Ursachen zu vermuten und Ratschläge für die nächsten Schritte zu geben. Die Diagnose kann sogar direkt an die eigene Ärzt_in weitergeleitet werden.
 
-<img src="/act/ada-health/ada-health.jpg">
+{{< img name="ada-health" alt="Daten löschen lassen bei Ada Health-App" >}}
 
 Das klingt erst einmal nützlich und wird auch von Nutzer_innen angenommen. Laut [eigenen Angaben](https://ada.com/de/milestones/) des Anbieters haben bereits 8 Millionen Menschen die App genutzt und 15 Millionen Analysen durchgeführt, zahlreiche Medien haben über das Angebot berichtet.
 

--- a/content/de/act/ada-health/index.md
+++ b/content/de/act/ada-health/index.md
@@ -10,6 +10,8 @@
 
 Die App *Ada Health* stellt sich auf ihrer [Webseite](https://ada.com/de/) als „Deine Gesundheitshelferin” vor. Per interaktivem Chat können Nutzer_innen der App die Symptome ihrer Krankheiten mitteilen, welche diese dann verwendet um mögliche Ursachen zu vermuten und Ratschläge für die nächsten Schritte zu geben. Die Diagnose kann sogar direkt an die eigene Ärzt_in weitergeleitet werden.
 
+<img src="/act/ada-health/ada-health.jpg">
+
 Das klingt erst einmal nützlich und wird auch von Nutzer_innen angenommen. Laut [eigenen Angaben](https://ada.com/de/milestones/) des Anbieters haben bereits 8 Millionen Menschen die App genutzt und 15 Millionen Analysen durchgeführt, zahlreiche Medien haben über das Angebot berichtet.
 
 Doch leider stellt sich heraus, dass ein genauerer Blick hinter die Kulissen nötig ist. Die Informationen, die über die App gesammelt und an den Anbieter geschickt werden, sind höchst sensible Daten. Nicht umsonst stellt die **DSGVO** (**Datenschutz-Grundverordnung**) Gesundheitsdaten unter [besonderen Schutz]({{< ref "gdpr-cheat-sheet" >}}#besondere-kategorien-personenbezogener-daten). Hier ist es umso wichtiger, dass die Verarbeitung sorgfältig und nur im nötigen Rahmen geschieht, um Verbraucher_innen zu schützen und unnötige Gefahren zu vermeiden.

--- a/content/de/act/deutsche-wohnen/index.md
+++ b/content/de/act/deutsche-wohnen/index.md
@@ -10,7 +10,7 @@
 
 Die Deutsche Wohnen SE ist eines der größten Immobilienunternehmen in Deutschland. [Nach eigenen Angaben](https://www.deutsche-wohnen.com/ueber-uns/unternehmen/unternehmensprofil/) verwaltet sie mehr als 150.000 Immobilien in Deutschland. Dementsprechend kommt das Unternehmen aus Berlin in Kontakt mit den Daten zahlreicher Mieter_innen.
 
-<img src="/act/deutsche-wohnen/deutsche-wohnen.jpg">
+{{< img name="deutsche-wohnen" alt="Rekordbußgeld gegen Deutsche Wohnen – frag Deine Daten an!" >}}
 
 Wie sich jetzt herausgestellt hat, hat die Deutsche Wohnen dabei leider nicht auf die Grundsätze des Datenschutz geachtet. Wie die Berliner Datenschutzbehörde (BlnBDI) in einer [Pressemitteilung](https://www.datenschutz-berlin.de/fileadmin/user_upload/pdf/pressemitteilungen/2019/20191105-PM-Bussgeld_DW.pdf) berichtet, hatte man bereits 2017 – noch vor Einführung der DSGVO – gravierende Mängel im Archivsystem des Unternehmens festgestellt. So habe dieses keine Möglichkeit vorgesehen, nicht mehr erforderliche Daten zu löschen. Auch eine Überprüfung, ob die Speicherung von Mieter_innendaten rechtmäßig oder überhaupt erforderlich ist, habe nicht stattgefunden.  
 So wurden dauerhaft auch sensible Daten der Mieter_innen, darunter Gehaltsbescheinigungen, Auszüge aus Arbeits- und Ausbildungsverträgen, Steuer-, Sozial- und Krankenversicherungsdaten sowie Kontoauszüge gespeichert.

--- a/content/de/act/deutsche-wohnen/index.md
+++ b/content/de/act/deutsche-wohnen/index.md
@@ -10,7 +10,7 @@
 
 Die Deutsche Wohnen SE ist eines der größten Immobilienunternehmen in Deutschland. [Nach eigenen Angaben](https://www.deutsche-wohnen.com/ueber-uns/unternehmen/unternehmensprofil/) verwaltet sie mehr als 150.000 Immobilien in Deutschland. Dementsprechend kommt das Unternehmen aus Berlin in Kontakt mit den Daten zahlreicher Mieter_innen.
 
-<img src="/act/img/deutsche-wohnen.jpg">
+<img src="/act/deutsche-wohnen/deutsche-wohnen.jpg">
 
 Wie sich jetzt herausgestellt hat, hat die Deutsche Wohnen dabei leider nicht auf die Grundsätze des Datenschutz geachtet. Wie die Berliner Datenschutzbehörde (BlnBDI) in einer [Pressemitteilung](https://www.datenschutz-berlin.de/fileadmin/user_upload/pdf/pressemitteilungen/2019/20191105-PM-Bussgeld_DW.pdf) berichtet, hatte man bereits 2017 – noch vor Einführung der DSGVO – gravierende Mängel im Archivsystem des Unternehmens festgestellt. So habe dieses keine Möglichkeit vorgesehen, nicht mehr erforderliche Daten zu löschen. Auch eine Überprüfung, ob die Speicherung von Mieter_innendaten rechtmäßig oder überhaupt erforderlich ist, habe nicht stattgefunden.  
 So wurden dauerhaft auch sensible Daten der Mieter_innen, darunter Gehaltsbescheinigungen, Auszüge aus Arbeits- und Ausbildungsverträgen, Steuer-, Sozial- und Krankenversicherungsdaten sowie Kontoauszüge gespeichert.

--- a/content/de/act/drk-brandenburg-datenleck/index.md
+++ b/content/de/act/drk-brandenburg-datenleck/index.md
@@ -10,7 +10,7 @@
 
 Das Deutsche Rote Kreuz (DRK) Brandenburg hat über mehrere Jahre sensible Gesundheitsdaten von Patient_innen kaum geschützt auf einem Server abgelegt. Hacker hätten einfach auf diese sensiblen Daten zugreifen und sie sogar manipulieren können. Betroffen sind Daten zu mehr als 111.000 Einsatzfahrten des DRK für über 30.000 Patient_innen aus den letzten 12 Jahren.
 
-<img src="/act/drk-brandenburg-datenleck/drk-brandenburg-datenleck.jpg">
+{{< img name="drk-brandenburg-datenleck" alt="Datenleck beim DRK Brandenburg – bist Du betroffen?" >}}
 
 Entdeckt hatte ein 18-jähriger Hacker die Sicherheitslücke laut [einem Artikel von tagesschau.de](https://www.tagesschau.de/investigativ/br-recherche/datenleck-drk-101.html) schon im November 2019. Er fand die Passwörter von Administratoren und konnte damit nicht nur auf die Daten mehrerer DRK-Kreisverbände zugreifen, sondern hätte diese theoretisch auch verändern können.  
 Obwohl er die Schwachstelle an den Kreisverband meldete, sperrte dieser nur den Zugang zu einer der Seiten. Das eigentliche Problem wurde aber zunächst nicht gelöst, sodass der Zugang laut Recherchen von BR, RBB und SZ noch bis Mitte Januar 2020 offen war.

--- a/content/de/act/drk-brandenburg-datenleck/index.md
+++ b/content/de/act/drk-brandenburg-datenleck/index.md
@@ -10,7 +10,7 @@
 
 Das Deutsche Rote Kreuz (DRK) Brandenburg hat über mehrere Jahre sensible Gesundheitsdaten von Patient_innen kaum geschützt auf einem Server abgelegt. Hacker hätten einfach auf diese sensiblen Daten zugreifen und sie sogar manipulieren können. Betroffen sind Daten zu mehr als 111.000 Einsatzfahrten des DRK für über 30.000 Patient_innen aus den letzten 12 Jahren.
 
-<img src="/act/img/drk-brandenburg-datenleck.jpg">
+<img src="/act/drk-brandenburg-datenleck/drk-brandenburg-datenleck.jpg">
 
 Entdeckt hatte ein 18-jähriger Hacker die Sicherheitslücke laut [einem Artikel von tagesschau.de](https://www.tagesschau.de/investigativ/br-recherche/datenleck-drk-101.html) schon im November 2019. Er fand die Passwörter von Administratoren und konnte damit nicht nur auf die Daten mehrerer DRK-Kreisverbände zugreifen, sondern hätte diese theoretisch auch verändern können.  
 Obwohl er die Schwachstelle an den Kreisverband meldete, sperrte dieser nur den Zugang zu einer der Seiten. Das eigentliche Problem wurde aber zunächst nicht gelöst, sodass der Zugang laut Recherchen von BR, RBB und SZ noch bis Mitte Januar 2020 offen war.

--- a/content/de/blog/ausweispflichten/index.md
+++ b/content/de/blog/ausweispflichten/index.md
@@ -10,7 +10,7 @@
     "license": "cc-by-4.0"
 }
 
-<img src="/blog/ausweispflichten/wie-ausweisen.png">
+{{< img name="wie-ausweisen" alt="Wie muss ich mich ausweisen?" >}}
 
 Unternehmen versuchen immer wieder, unliebsame Datenschutzanfragen von Nutzer_innen abzuwehren. Dies geschieht häufig, indem die Unternehmen von den Nutzer_innen detaillierte Nachweise über ihre Identität verlangen. Teilweise fordern die Unternehmen sogar Ausweiskopien an. Solche Identitätsnachweise sind vor allem dann ein Problem, wenn man sich als Nutzer_in nicht mit dem richtigen Namen oder nur mit solchen Kontaktinformationen angemeldet hat, aus denen die Anbieter_in nicht ohne Weiteres auf die Person der Nutzer_in schließen kann. In diesen Fällen würde die Anbieter_in durch den Identitätsnachweis weitere persönliche Daten erhalten. Auf der anderen Seite haben die Unternehmen jedoch ein Interesse daran, die Daten nur an die betreffenden Nutzer_innen herauszugeben, um sich nicht selbst eines Datenschutzverstoßes schuldig zu machen.
 

--- a/content/de/blog/ausweispflichten/index.md
+++ b/content/de/blog/ausweispflichten/index.md
@@ -10,6 +10,8 @@
     "license": "cc-by-4.0"
 }
 
+<img src="/blog/ausweispflichten/wie-ausweisen.png">
+
 Unternehmen versuchen immer wieder, unliebsame Datenschutzanfragen von Nutzer_innen abzuwehren. Dies geschieht häufig, indem die Unternehmen von den Nutzer_innen detaillierte Nachweise über ihre Identität verlangen. Teilweise fordern die Unternehmen sogar Ausweiskopien an. Solche Identitätsnachweise sind vor allem dann ein Problem, wenn man sich als Nutzer_in nicht mit dem richtigen Namen oder nur mit solchen Kontaktinformationen angemeldet hat, aus denen die Anbieter_in nicht ohne Weiteres auf die Person der Nutzer_in schließen kann. In diesen Fällen würde die Anbieter_in durch den Identitätsnachweis weitere persönliche Daten erhalten. Auf der anderen Seite haben die Unternehmen jedoch ein Interesse daran, die Daten nur an die betreffenden Nutzer_innen herauszugeben, um sich nicht selbst eines Datenschutzverstoßes schuldig zu machen.
 
 ## Dienste bei denen sich die Nutzer_in angemeldet hat

--- a/content/de/blog/request-specification/index.md
+++ b/content/de/blog/request-specification/index.md
@@ -13,6 +13,8 @@
 
 Gemäß Art. 15 DSGVO und konkreter dem Erwägungsgrund 63 S. 7[^1] darf der_die Verantwortliche von der betroffenen Person eine Präzisierung der Anfrage im Rahmen ihrer Ausübung des Auskunftsrechts verlangen. Um diese Aufforderung verlangen zu können, muss der_die Verantwortliche eine große Menge von Daten in Bezug auf die betroffene Person verarbeiten. 
 
+<img src="/blog/request-specification/praezisierung-von-auskunftsanfragen.png">
+
 Zunächst ist es wichtig zu klären, ob die betroffene Person nach Verlangen des_der Verantwortlichen verpflichtet ist, eine Präzisierung vorzunehmen. Um diese Frage zu beantworten, muss zuerst eine Unterscheidung gemacht werden; Die Auskunftsanfrage an eine öffentliche Stelle einerseits und die im Rahmen der Privatwirtschaft.
 
 ## Anfrage an öffentliche Stellen

--- a/content/de/blog/request-specification/index.md
+++ b/content/de/blog/request-specification/index.md
@@ -13,7 +13,7 @@
 
 Gemäß Art. 15 DSGVO und konkreter dem Erwägungsgrund 63 S. 7[^1] darf der_die Verantwortliche von der betroffenen Person eine Präzisierung der Anfrage im Rahmen ihrer Ausübung des Auskunftsrechts verlangen. Um diese Aufforderung verlangen zu können, muss der_die Verantwortliche eine große Menge von Daten in Bezug auf die betroffene Person verarbeiten. 
 
-<img src="/blog/request-specification/praezisierung-von-auskunftsanfragen.png">
+{{< img name="praezisierung-von-auskunftsanfragen" alt="Präzisierung von Auskunftsanfragen" >}}
 
 Zunächst ist es wichtig zu klären, ob die betroffene Person nach Verlangen des_der Verantwortlichen verpflichtet ist, eine Präzisierung vorzunehmen. Um diese Frage zu beantworten, muss zuerst eine Unterscheidung gemacht werden; Die Auskunftsanfrage an eine öffentliche Stelle einerseits und die im Rahmen der Privatwirtschaft.
 


### PR DESCRIPTION
Fixes #329 

Some entries are listed on the [act](https://www.datenanfragen.de/act/) and [blog](https://www.datenanfragen.de/blog/) site with a thumbnail of
the featured image. Some of them also reference that banner image in
the metadata section of the entry, but the image itself is not shown
on the entry site.
All entries that reference the banner ("notice" section) in their
metadata should now have the correct banner image set.