### PR TITLE
Better link styling without inline-block

### DIFF
--- a/src/styles/framework.scss
+++ b/src/styles/framework.scss
@@ -200,33 +200,20 @@ span > a,
     &:not(.button):not(.no-link-decoration) {
         position: relative;
         text-decoration: none;
-        display: inline-block;
-        padding: 0 0px;
         @media (prefers-reduced-motion: no-preference) {
-            transition: color ease 0.3s;
+            transition: all ease 0.3s;
         }
 
-        &::after {
-            content: '';
-            position: absolute;
-            z-index: -1;
-            width: 100%;
-            height: 2px;
-            left: 0;
-            bottom: 0;
-            background-color: $accent-color;
-            @media (prefers-reduced-motion: no-preference) {
-                transition: all ease 0.3s;
-            }
-        }
+        // Very loosely inspired by: https://codepen.io/aaroniker/pen/pojaBvb
+        background-image: linear-gradient(0deg, $accent-color 0%, $accent-color 100%);
+        background-position: bottom;
+        background-repeat: no-repeat;
+        background-size: 100% 2px;
 
         &:hover,
         &:focus {
             color: color('white');
-
-            &::after {
-                height: 100%;
-            }
+            background-size: 100% 100%;
         }
     }
 }


### PR DESCRIPTION
This PR finally cleans up the link styling to not use `inline-block` anymore.

An example to illustrate why this is important:

![screenshot_2020-06-18T23-50-17](https://user-images.githubusercontent.com/4048809/85075487-cf15ea80-b1ad-11ea-9d83-94a1803f6024.png)


