### PR TITLE
Transparency page updates: Re-add old info, sensible ordering and compensated lectures

### DIFF
--- a/content/de/verein/transparency.md
+++ b/content/de/verein/transparency.md
@@ -48,8 +48,8 @@ Aktuell sind keine Beisitzer_innen bestellt.
 
 ## 5. Tätigkeitsbericht
 
-s. [Jahresbericht 2018 (S. 5 ff.)](https://static.dacdn.de/docs/bericht-2018.pdf)  
-s. [Jahresbericht 2019 (S. 5 ff.)](https://static.dacdn.de/docs/bericht-2019.pdf)
+s. [Jahresbericht 2019 (S. 5 ff.)](https://static.dacdn.de/docs/bericht-2019.pdf)  
+s. [Jahresbericht 2018 (S. 5 ff.)](https://static.dacdn.de/docs/bericht-2018.pdf)
 
 ## 6. Personalstruktur
 
@@ -59,16 +59,16 @@ Anzahl Ehrenamtliche: 2
 
 ## 7. Angaben zur Mittelherkunft
 
-s. [Jahresbericht 2018 (S. 9 f.)](https://static.dacdn.de/docs/bericht-2018.pdf)  
-s. [Jahresbericht 2019 (S. 10 f.)](https://static.dacdn.de/docs/bericht-2019.pdf)
+s. [Jahresbericht 2019 (S. 10 f.)](https://static.dacdn.de/docs/bericht-2019.pdf)  
+s. [Jahresbericht 2018 (S. 9 f.)](https://static.dacdn.de/docs/bericht-2018.pdf)
 
-Vermögensstand Ende 2018: 119,70 €  
-Vermögensstand Ende 2019: 87,90 €
+Vermögensstand Ende 2019: 87,90 €  
+Vermögensstand Ende 2018: 119,70 €
 
 ## 8. Angaben zur Mittelverwendung
 
-s. [Jahresbericht 2018 (S. 9 f.)](https://static.dacdn.de/docs/bericht-2018.pdf)  
-s. [Jahresbericht 2019 (S. 10 f.)](https://static.dacdn.de/docs/bericht-2019.pdf)
+s. [Jahresbericht 2019 (S. 10 f.)](https://static.dacdn.de/docs/bericht-2019.pdf)  
+s. [Jahresbericht 2018 (S. 9 f.)](https://static.dacdn.de/docs/bericht-2018.pdf)
 
 ## 9. Gesellschaftsrechtliche Verbundenheit mit Dritten
 
@@ -77,18 +77,6 @@ Der Verein steht in keinerlei gesellschaftsrechtlicher Verbundenheit mit Dritten
 ## 10. Namen von Personen, deren jährliche Zahlungen mehr als 10 % des Gesamtjahresbudgets ausmachen
 
 Diese Informationen veröffentlichen wir jährlich zusammen mit dem Jahresbericht.
-
-### 2018
-
-#### Natürliche Personen
-
-- Anonymer Mitgliedsbeitrag: 128 €
-- Anonymer Mitgliedsbeitrag: 50 €
-- Anonymer Mitgliedsbeitrag: 42 €
-
-#### Juristische Personen
-
-In 2018 haben wir keine Spenden oder Beiträge von juristischen Personen erhalten.
 
 ### 2019
 
@@ -106,3 +94,15 @@ In 2018 haben wir keine Spenden oder Beiträge von juristischen Personen erhalte
 
 - Mitgliedsbeitrag der ByteSchneiderei GmbH: 50 €
 - Mitgliedsbeitrag der KlexHub UG (haftungsbeschränkt): 32 €
+
+### 2018
+
+#### Natürliche Personen
+
+- Anonymer Mitgliedsbeitrag: 128 €
+- Anonymer Mitgliedsbeitrag: 50 €
+- Anonymer Mitgliedsbeitrag: 42 €
+
+#### Juristische Personen
+
+In 2018 haben wir keine Spenden oder Beiträge von juristischen Personen erhalten.

--- a/content/de/verein/transparency.md
+++ b/content/de/verein/transparency.md
@@ -9,7 +9,7 @@
 
 Damit Du uns vertrauen kannst, haben wir uns verpflichtet, unsere Abläufe, Finanzen und Entscheidungen so transparent wie möglich zu machen. Wir sind deshalb Teil der [Initiative Transparente Zivilgesellschaft](https://www.transparency.de/mitmachen/initiative-transparente-zivilgesellschaft/), die uns stichprobenartig kontrollieren kann und dafür sorgt, dass unser Versprechen zur transparenten Geschäftsführung kein leeres bleibt. Auf dieser Seite sind nun alle wichtigen Informationen zusammengefasst, die wir im Rahmen unseres Transparenzberichts veröffentlichen.
 
-Die Informationen sind auf dem Stand vom 08. Mai 2020.
+Die Informationen sind auf dem Stand vom 27. Mai 2020.
 
 ## 1. Name, Sitz, Anschrift und Gründungsjahr
 
@@ -76,9 +76,23 @@ Der Verein steht in keinerlei gesellschaftsrechtlicher Verbundenheit mit Dritten
 
 ## 10. Namen von Personen, deren jährliche Zahlungen mehr als 10 % des Gesamtjahresbudgets ausmachen
 
-Die Informationen sind auf dem Stand des [Jahresbericht 2019](https://static.dacdn.de/docs/bericht-2019.pdf).
+Diese Informationen veröffentlichen wir jährlich zusammen mit dem Jahresbericht.
 
-### Natürliche Personen
+### 2018
+
+#### Natürliche Personen
+
+- Anonymer Mitgliedsbeitrag: 128 €
+- Anonymer Mitgliedsbeitrag: 50 €
+- Anonymer Mitgliedsbeitrag: 42 €
+
+#### Juristische Personen
+
+In 2018 haben wir keine Spenden oder Beiträge von juristischen Personen erhalten.
+
+### 2019
+
+#### Natürliche Personen
 
 - Anonymer Mitgliedsbeitrag: 128 €
 - Anonymer Mitgliedsbeitrag: 42 €
@@ -88,7 +102,7 @@ Die Informationen sind auf dem Stand des [Jahresbericht 2019](https://static.dac
 
 - einmalige Spende (anonym): 50 €
 
-### Juristische Personen
+#### Juristische Personen
 
 - Mitgliedsbeitrag der ByteSchneiderei GmbH: 50 €
 - Mitgliedsbeitrag der KlexHub UG (haftungsbeschränkt): 32 €

--- a/content/de/verein/transparency.md
+++ b/content/de/verein/transparency.md
@@ -9,7 +9,7 @@
 
 Damit Du uns vertrauen kannst, haben wir uns verpflichtet, unsere Abläufe, Finanzen und Entscheidungen so transparent wie möglich zu machen. Wir sind deshalb Teil der [Initiative Transparente Zivilgesellschaft](https://www.transparency.de/mitmachen/initiative-transparente-zivilgesellschaft/), die uns stichprobenartig kontrollieren kann und dafür sorgt, dass unser Versprechen zur transparenten Geschäftsführung kein leeres bleibt. Auf dieser Seite sind nun alle wichtigen Informationen zusammengefasst, die wir im Rahmen unseres Transparenzberichts veröffentlichen.
 
-Die Informationen sind auf dem Stand vom 27. Mai 2020.
+Die Informationen sind auf dem Stand vom 19. Juni 2020.
 
 ## 1. Name, Sitz, Anschrift und Gründungsjahr
 
@@ -106,3 +106,17 @@ Diese Informationen veröffentlichen wir jährlich zusammen mit dem Jahresberich
 #### Juristische Personen
 
 In 2018 haben wir keine Spenden oder Beiträge von juristischen Personen erhalten.
+
+---
+
+Die folgenden Abschnitte gehen über die zehn durch die Initiative Transparente Zivilgesellschaft geforderten Informationen hinaus. Uns ist es wichtig, auch in diesen Punkten transparent zu sein.
+
+## 11. Vergütete Vorträge
+
+Unser [Vorstand]({{< ref "verein/board" >}}) arbeitet grundsätzlich ehrenamtlich und erhält durch den Verein keinerlei Zahlungen für seine Arbeit. Teilweise können Vereinsmitglieder allerdings von externen Organisationen ein Honorar für Vorträge zu Themen, die den Verein betreffen, erhalten. Für solche vergüteten Vorträge werden selbstverständlich keine Vereinsmittel aufgewendet, sie liegen alleine in der privaten Verantwortung der entsprechenden Mitglieder.
+
+Der Vorstand hat sich selbst verpflichtet, Vorträge, für die Vorstandsmitglieder eine Vergütung von externen Organisationen erhalten haben, hier öffentlich zu dokumentieren.
+
+### 2020
+
+* Im März 2020 hat die Humboldt-Universität zu Berlin Benjamin Altpeter und Lorenz Sieben im Rahmen der [HLCI](http://www.hlci.de/) privat eingeladen, ein [Seminar zu Datenanfragen.de]({{< ref "verein/event/hlci-berlin-2020" >}}) als Gastvortrag zu halten. Die Humboldt-Universität hat die Kosten für die Zugreise und Übernachtung übernommen und den beiden ein Honorar von jeweils 250&nbsp;€ gezahlt. Benni und Lorenz haben sich freiwillig entschieden, die Hälfte des Honorars an den Verein zu spenden.

--- a/content/en/verein/transparency.md
+++ b/content/en/verein/transparency.md
@@ -7,7 +7,7 @@
 
 In order for you to be able to trust us, we pledged to be as transparent as possible about our procedures, finances and decisions. Because of that, we have joined the [Initiative for a Transparent Civil Society](https://www.transparency.de/mitmachen/initiative-transparente-zivilgesellschaft/), an initiative by the German branch of Transparency International, which is allowed to audit us on a sample basis. They ensure that we will keep our promise of transparent management. On this page we summarized all the important information that we publish as part of that.
 
-This information has been last updated on May 27, 2020.
+This information has been last updated on June 19, 2020.
 
 ## 1. Name, registered seat, address and date of foundation
 
@@ -104,3 +104,17 @@ We publish this information on a yearly basis in conjunction with the publishing
 #### Organisations
 
 No organisations contributed to our budget in 2018.
+
+---
+
+The following sections go beyond the ten pieces of information required by the Initiative for a Transparent Civil Society. We believe it is important to be transparent on these points as well.
+
+## 11. Compensated lectures
+
+Our [board members]({{< ref "verein/board" >}}) work on a strictly voluntary basis and receive no payment from the association for their work. In some cases, however, members of the association can receive compensation from external organizations for lectures on topics that concern the association. Of course, no funds of the association are used for such compensated lectures, they are the private responsibility of the respective members.
+
+The board has committed itself to publicly document lectures here for which board members have received compensation from external organizations.
+
+### 2020
+
+* In March 2020, the Humboldt University of Berlin invited Benjamin Altpeter and Lorenz Sieben to give a [seminar on Datenanfragen.de](https://www.datenanfragen.de/verein/event/hlci-berlin-2020/) (post in German) as a guest lecture at the [HLCI](http://www.hlci.de/). The Humboldt University has covered the train travel and accommodation costs and paid them a compensation of 250&nbsp;€ each. Benni and Lorenz voluntarily decided to donate half of the compensation to the association.

--- a/content/en/verein/transparency.md
+++ b/content/en/verein/transparency.md
@@ -7,7 +7,7 @@
 
 In order for you to be able to trust us, we pledged to be as transparent as possible about our procedures, finances and decisions. Because of that, we have joined the [Initiative for a Transparent Civil Society](https://www.transparency.de/mitmachen/initiative-transparente-zivilgesellschaft/), an initiative by the German branch of Transparency International, which is allowed to audit us on a sample basis. They ensure that we will keep our promise of transparent management. On this page we summarized all the important information that we publish as part of that.
 
-This information has been last updated on May 08, 2020.
+This information has been last updated on May 27, 2020.
 
 ## 1. Name, registered seat, address and date of foundation
 
@@ -74,9 +74,23 @@ The association is in no corporate relationships with any third parties.
 
 ## 10. Names of entities whose donations make up more than 10% of the yearly budget
 
-The information is based on the [yearly report of 2019 (German)](https://static.dacdn.de/docs/bericht-2019.pdf).
+We publish this information on a yearly basis in conjunction with the publishing of the yearly report.
 
-### People
+### 2018
+
+#### People
+
+- Anonymous membership fee: 128 €
+- Anonymous membership fee: 50 €
+- Anonymous membership fee: 42 € 
+
+#### Organisations
+
+No organisations contributed to our budget in 2018.
+
+### 2019
+
+#### People
 
 - Anonymous membership fee: 128 €
 - Anonymous membership fee: 42 €
@@ -86,7 +100,7 @@ The information is based on the [yearly report of 2019 (German)](https://static.
 
 - non-recurring donation (anonymous): 50 €
 
-### Organisations
+#### Organisations
 
 - Membership fee by ByteSchneiderei GmbH: 50 €
 - Membership fee by KlexHub UG (haftungsbeschränkt): 32 €

--- a/content/en/verein/transparency.md
+++ b/content/en/verein/transparency.md
@@ -46,8 +46,8 @@ There are currently no assessors on the board.
 
 ## 5. Report of activities
 
-see [Yearly report 2018 (German, p. 5 ff.)](https://static.dacdn.de/docs/bericht-2018.pdf)  
-see [Yearly report 2019 (German, p. 5 ff.)](https://static.dacdn.de/docs/bericht-2019.pdf)
+see [Yearly report 2019 (German, p. 5 ff.)](https://static.dacdn.de/docs/bericht-2019.pdf)  
+see [Yearly report 2018 (German, p. 5 ff.)](https://static.dacdn.de/docs/bericht-2018.pdf)
 
 ## 6. Staff structure
 
@@ -57,16 +57,16 @@ Number of volunteers: 2
 
 ## 7. Funding sources
 
-see [Yearly report 2018 (German, p. 9 f.)](https://static.dacdn.de/docs/bericht-2018.pdf)  
-see [Yearly report 2019 (German, p. 10 f.)](https://static.dacdn.de/docs/bericht-2019.pdf)
+see [Yearly report 2019 (German, p. 10 f.)](https://static.dacdn.de/docs/bericht-2019.pdf)  
+see [Yearly report 2018 (German, p. 9 f.)](https://static.dacdn.de/docs/bericht-2018.pdf)
 
-Financial assets at the end of 2018: 119,70 €  
-Financial assets at the end of 2018: 87,90 €
+Financial assets at the end of 2019: 87,90 €  
+Financial assets at the end of 2018: 119,70 €
 
 ## 8. Use of funds
 
-see [Yearly report 2018 (German, p. 9 f.)](https://static.dacdn.de/docs/bericht-2018.pdf)  
-see [Yearly report 2019 (German, p. 10 f.)](https://static.dacdn.de/docs/bericht-2019.pdf)
+see [Yearly report 2019 (German, p. 10 f.)](https://static.dacdn.de/docs/bericht-2019.pdf)  
+see [Yearly report 2018 (German, p. 9 f.)](https://static.dacdn.de/docs/bericht-2018.pdf)
 
 ## 9. Corporate relationships with third parties 
 
@@ -75,18 +75,6 @@ The association is in no corporate relationships with any third parties.
 ## 10. Names of entities whose donations make up more than 10% of the yearly budget
 
 We publish this information on a yearly basis in conjunction with the publishing of the yearly report.
-
-### 2018
-
-#### People
-
-- Anonymous membership fee: 128 €
-- Anonymous membership fee: 50 €
-- Anonymous membership fee: 42 € 
-
-#### Organisations
-
-No organisations contributed to our budget in 2018.
 
 ### 2019
 
@@ -104,3 +92,15 @@ No organisations contributed to our budget in 2018.
 
 - Membership fee by ByteSchneiderei GmbH: 50 €
 - Membership fee by KlexHub UG (haftungsbeschränkt): 32 €
+
+### 2018
+
+#### People
+
+- Anonymous membership fee: 128 €
+- Anonymous membership fee: 50 €
+- Anonymous membership fee: 42 € 
+
+#### Organisations
+
+No organisations contributed to our budget in 2018.

--- a/content/fr/verein/transparency.md
+++ b/content/fr/verein/transparency.md
@@ -47,8 +47,8 @@ Il n'y a pour le moment aucun conseiller au sein du comité directeur.
 
 ## 5. Rapports d'activité
 
-Voir [Rapport annuel 2018 (en allemand, p. 5 et suiv.)](https://static.dacdn.de/docs/bericht-2018.pdf)  
-Voir [Rapport annuel 2019 (en allemand, p. 5 et suiv.)](https://static.dacdn.de/docs/bericht-2019.pdf)
+Voir [Rapport annuel 2019 (en allemand, p. 5 et suiv.)](https://static.dacdn.de/docs/bericht-2019.pdf)  
+Voir [Rapport annuel 2018 (en allemand, p. 5 et suiv.)](https://static.dacdn.de/docs/bericht-2018.pdf)
 
 ## 6. Personnel
 
@@ -58,34 +58,22 @@ Nombre de bénévoles : 2
 
 ## 7. Sources de financement
 
-Voir [Rapport annuel 2018 (en allemand, p. 9 et suiv.)](https://static.dacdn.de/docs/bericht-2018.pdf)  
-Voir [Rapport annuel 2019 (en allemand, p. 10 et suiv.)](https://static.dacdn.de/docs/bericht-2019.pdf)
+Voir [Rapport annuel 2019 (en allemand, p. 10 et suiv.)](https://static.dacdn.de/docs/bericht-2019.pdf)  
+Voir [Rapport annuel 2018 (en allemand, p. 9 et suiv.)](https://static.dacdn.de/docs/bericht-2018.pdf)
 
-Actifs financiers fin 2018 : 119,70 €  
-Actifs financiers fin 2019 : 87,90 €
+Actifs financiers fin 2019 : 87,90 €  
+Actifs financiers fin 2018 : 119,70 €
 
 ## 8. Utilisation des fonds
 
-Voir [Rapport annuel 2018 (en allemand, p. 9 et suiv.)](https://static.dacdn.de/docs/bericht-2018.pdf)  
-Voir [Rapport annuel 2019 (en allemand, p. 10 et suiv.)](https://static.dacdn.de/docs/bericht-2019.pdf)
+Voir [Rapport annuel 2019 (en allemand, p. 10 et suiv.)](https://static.dacdn.de/docs/bericht-2019.pdf)  
+Voir [Rapport annuel 2018 (en allemand, p. 9 et suiv.)](https://static.dacdn.de/docs/bericht-2018.pdf)
 
 ## 9. Relations d'affaires avec des tiers 
 
 L'association n'entretient aucune relation d'affaires avec des tiers.
 
 ## 10. Noms des entités dont les dons représentent plus de 10 % du budget annuel
-
-### 2018
-
-#### Personnes
-
-- Cotisation anonyme : 128 €
-- Cotisation anonyme : 50 €
-- Cotisation anonyme : 42 € 
-
-#### Organisations
-
-Aucune organisation n'a contribué à notre budget en 2018.
 
 ### 2019
 
@@ -103,3 +91,15 @@ Aucune organisation n'a contribué à notre budget en 2018.
 
 - Cotisation par ByteSchneiderei GmbH : 50 €
 - Cotisation par KlexHub UG (haftungsbeschränkt) : 32 €
+
+### 2018
+
+#### Personnes
+
+- Cotisation anonyme : 128 €
+- Cotisation anonyme : 50 €
+- Cotisation anonyme : 42 € 
+
+#### Organisations
+
+Aucune organisation n'a contribué à notre budget en 2018.

--- a/content/fr/verein/transparency.md
+++ b/content/fr/verein/transparency.md
@@ -8,7 +8,7 @@
 
 Afin que vous puissiez nous faire confiance, nous nous sommes engagés à être aussi transparents que possible sur nos procédures, nos finances et nos décisions. C'est pourquoi nous avons adhéré à l'[Initiative pour une Société Civile Transparente](https://www.transparency.de/mitmachen/initiative-transparente-zivilgesellschaft/), une initiative de la branche allemande de Transparency International, qui est autorisée à nous contrôler par échantillonnage. Ils garantissent le respect de notre promesse de gestion transparente. Sur cette page, nous avons résumé toutes les informations importantes que nous publions dans le cadre de cette initiative.
 
-Ces informations ont été mises à jour pour la dernière fois le 8 mai 2020.
+Ces informations ont été mises à jour pour la dernière fois le 19 juin 2020.
 
 ## 1. Nom, siège social, adresse et date de création
 
@@ -103,3 +103,17 @@ L'association n'entretient aucune relation d'affaires avec des tiers.
 #### Organisations
 
 Aucune organisation n'a contribué à notre budget en 2018.
+
+---
+
+Les sections suivantes vont au-delà des dix informations requises par l'Initiative pour une Société Civile Transparente. Cependant, nous pensons qu'il est important d'être transparent sur ces points également.
+
+## 11. Conférences rémunérées
+
+Les membres de notre [comité directeur]({{< ref "verein/board" >}}) travaillent sur une base strictement volontaire et ne reçoivent aucune rémunération de l'association pour leur travail. Dans certains cas, cependant, les membres de l'association peuvent recevoir une compensation de la part d'organisations externes pour des conférences sur des sujets qui concernent l'association. Bien entendu, aucun fonds de l'association n'est utilisé pour de telles conférences rémunérées, elles relèvent de la responsabilité privée des membres respectifs.
+
+Le comité s'est engagé à documenter publiquement les conférences données sur cette page et pour lesquelles les membres du comité ont reçu une compensation de la part d'organisations externes.
+
+### 2020
+
+* En mars 2020, l'université Humboldt de Berlin a invité Benjamin Altpeter et Lorenz Sieben à donner un [séminaire sur Datenanfragen.de](https://www.datenanfragen.de/verein/event/hlci-berlin-2020/) (article en allemand) en tant que conférencier invité à la [HLCI](http://www.hlci.de/). L'université Humboldt a pris en charge les frais de déplacement en train et d'hébergement et leur a versé une indemnité de 250&nbsp;€ chacun. Benni et Lorenz ont volontairement décidé de donner la moitié de cette compensation à l'association.

--- a/content/fr/verein/transparency.md
+++ b/content/fr/verein/transparency.md
@@ -8,7 +8,7 @@
 
 Afin que vous puissiez nous faire confiance, nous nous sommes engagés à être aussi transparents que possible sur nos procédures, nos finances et nos décisions. C'est pourquoi nous avons adhéré à l'[Initiative pour une Société Civile Transparente](https://www.transparency.de/mitmachen/initiative-transparente-zivilgesellschaft/), une initiative de la branche allemande de Transparency International, qui est autorisée à nous contrôler par échantillonnage. Ils garantissent le respect de notre promesse de gestion transparente. Sur cette page, nous avons résumé toutes les informations importantes que nous publions dans le cadre de cette initiative.
 
-Ces informations ont été mises à jour pour la dernière fois le 8<sup>e</sup> mai 2020.
+Ces informations ont été mises à jour pour la dernière fois le 8 mai 2020.
 
 ## 1. Nom, siège social, adresse et date de création
 

--- a/content/fr/verein/transparency.md
+++ b/content/fr/verein/transparency.md
@@ -8,7 +8,7 @@
 
 Afin que vous puissiez nous faire confiance, nous nous sommes engagés à être aussi transparents que possible sur nos procédures, nos finances et nos décisions. C'est pourquoi nous avons adhéré à l'[Initiative pour une Société Civile Transparente](https://www.transparency.de/mitmachen/initiative-transparente-zivilgesellschaft/), une initiative de la branche allemande de Transparency International, qui est autorisée à nous contrôler par échantillonnage. Ils garantissent le respect de notre promesse de gestion transparente. Sur cette page, nous avons résumé toutes les informations importantes que nous publions dans le cadre de cette initiative.
 
-Ces informations ont été mises à jour pour la dernière fois le 1<sup>er</sup> août 2019.
+Ces informations ont été mises à jour pour la dernière fois le 8<sup>e</sup> mai 2020.
 
 ## 1. Nom, siège social, adresse et date de création
 
@@ -47,7 +47,7 @@ Il n'y a pour le moment aucun conseiller au sein du comité directeur.
 
 ## 5. Rapports d'activité
 
-Voir [Rapport annuel 2018 (en allemand, p. 5 et suiv.)](https://static.dacdn.de/docs/bericht-2018.pdf)
+Voir [Rapport annuel 2018 (en allemand, p. 5 et suiv.)](https://static.dacdn.de/docs/bericht-2018.pdf)  
 Voir [Rapport annuel 2019 (en allemand, p. 5 et suiv.)](https://static.dacdn.de/docs/bericht-2019.pdf)
 
 ## 6. Personnel
@@ -58,14 +58,15 @@ Nombre de bénévoles : 2
 
 ## 7. Sources de financement
 
-Voir [Rapport annuel 2018 (en allemand, p. 9 et suiv.)](https://static.dacdn.de/docs/bericht-2018.pdf)
+Voir [Rapport annuel 2018 (en allemand, p. 9 et suiv.)](https://static.dacdn.de/docs/bericht-2018.pdf)  
 Voir [Rapport annuel 2019 (en allemand, p. 10 et suiv.)](https://static.dacdn.de/docs/bericht-2019.pdf)
 
-Actifs financiers fin 2018 : 119,70 €
+Actifs financiers fin 2018 : 119,70 €  
+Actifs financiers fin 2019 : 87,90 €
 
 ## 8. Utilisation des fonds
 
-Voir [Rapport annuel 2018 (en allemand, p. 9 et suiv.)](https://static.dacdn.de/docs/bericht-2018.pdf)
+Voir [Rapport annuel 2018 (en allemand, p. 9 et suiv.)](https://static.dacdn.de/docs/bericht-2018.pdf)  
 Voir [Rapport annuel 2019 (en allemand, p. 10 et suiv.)](https://static.dacdn.de/docs/bericht-2019.pdf)
 
 ## 9. Relations d'affaires avec des tiers 
@@ -74,16 +75,31 @@ L'association n'entretient aucune relation d'affaires avec des tiers.
 
 ## 10. Noms des entités dont les dons représentent plus de 10 % du budget annuel
 
-Ces informations sont basées sur le [rapport annuel de 2019 (en allemand)](https://static.dacdn.de/docs/bericht-2019.pdf).
+### 2018
 
-### Personnes
+#### Personnes
 
- - Cotisation anonyme : 128 €
- - Cotisation anonyme : 42 €
- - Cotisation anonyme : 36 €
- - Don unique (anonyme) : 50 €
+- Cotisation anonyme : 128 €
+- Cotisation anonyme : 50 €
+- Cotisation anonyme : 42 € 
 
-### Organisations
+#### Organisations
+
+Aucune organisation n'a contribué à notre budget en 2018.
+
+### 2019
+
+#### Personnes
+
+- Cotisation anonyme : 128 €
+- Cotisation anonyme : 42 €
+- Cotisation anonyme : 36 €
+
+<!-- Split the two lists. Without this comment they would end up as one list with stupidly large spacing in-between items. -->
+
+- Don unique (anonyme) : 50 €
+
+#### Organisations
 
 - Cotisation par ByteSchneiderei GmbH : 50 €
 - Cotisation par KlexHub UG (haftungsbeschränkt) : 32 €


### PR DESCRIPTION
Now that the respective board resolution has finally been passed, we can add information on compensated lectures to the transparency page.

@NathanBnm It would be great if you could apply those updates (only 47a6652 is relevant, I incorporated the other two commits already) to the French page as well. :) 