### PR TITLE
Fixes #337: Error handler improvements

### DIFF
--- a/src/Utility/errors.js
+++ b/src/Utility/errors.js
@@ -1,8 +1,9 @@
-export function rethrow(error, description, context) {
+export function rethrow(error, description, context, enduser_message = '') {
     // allow throwing from inside promise `catch` functions, see https://stackoverflow.com/a/30741722
     setTimeout(() => {
         if (description) error.description = description;
         if (context) error.context = context;
+        if (enduser_message) error.enduser_message = enduser_message;
         throw error;
     }, 0);
 }

--- a/src/error-handler.js
+++ b/src/error-handler.js
@@ -64,7 +64,7 @@ try {
         let mailto_url = 'mailto:dev@datenanfragen.de?' + 'subject=' + report_title + '&body=' + report_body;
 
         // Note: Unless debugging_enabled is set, this will never happen for Chrome. But considering what I mentioned above, this is probably a good thing.
-        if (debug_info.error.code <= 3 || debugging_enabled) {
+        if (!debug_info.error.code || debug_info.error.code <= 3 || debugging_enabled) {
             let dismiss = () => {
                 preact.render('', document.body, modal);
             };

--- a/src/error-handler.js
+++ b/src/error-handler.js
@@ -37,7 +37,11 @@ try {
                 'lineno',
                 'error',
                 'stack',
-                'enduser_message'
+                'enduser_message',
+                'defaultPrevented',
+                'eventPhase',
+                'isTrusted',
+                'returnValue'
             ])
         );
 

--- a/src/suggest-edit.js
+++ b/src/suggest-edit.js
@@ -172,19 +172,20 @@ document.getElementById('submit-suggest-form').onclick = () => {
     // we can control the ordering of the JSON to fix #187
     // (see https://stackoverflow.com/questions/16167581/sort-object-properties-and-json-stringify/40646557#comment70742750_40646557)
     let properties = getAllPropertyNamesInSchema(schema);
+    // we use a replacer to order the JSON
+    const body = JSON.stringify(
+        {
+            for: 'cdb',
+            data: data,
+            new: !PARAMETERS['slug']
+        },
+        ['for', 'data'].concat(properties, ['new'])
+    );
 
     fetch(SUBMIT_URL, {
         method: 'POST',
         headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
-        // we use a replacer to order the JSON
-        body: JSON.stringify(
-            {
-                for: 'cdb',
-                data: data,
-                new: !PARAMETERS['slug']
-            },
-            ['for', 'data'].concat(properties, ['new'])
-        )
+        body
     })
         .then(res => res.json())
         .then(res => {
@@ -193,11 +194,7 @@ document.getElementById('submit-suggest-form').onclick = () => {
         })
         .catch(err => {
             document.getElementById('loading-indicator').classList.add('hidden');
-            rethrow(err);
-            /* eslint-disable no-unused-vars */
-            let preact = require('preact');
-            /* eslint-enable no-unused-vars */
-            flash(<FlashMessage type="error">{t('error', 'suggest')}</FlashMessage>);
+            rethrow(err, 'POSTing the suggestion failed.', { submit_url: SUBMIT_URL, body }, t('error', 'suggest'));
         });
 };
 


### PR DESCRIPTION
This PR was originally sparked by #337. 

While working on that, I noticed a fairly major deficiency of the error handler: It didn't previously handle promise rejections which make up a fairly significant part of the—now mostly async— generator. This is now fixed as well.