### PR TITLE
Load the pdfworker.js only if it is needed, fixes #330

### DIFF
--- a/cypress/integration/components/generator.spec.js
+++ b/cypress/integration/components/generator.spec.js
@@ -1,0 +1,16 @@
+describe('Generator component', () => {
+    beforeEach(() => {
+        cy.visit('/generator');
+    });
+
+    it('has generated a blob URL', () => {
+        cy.get('.request-transport-medium-chooser')
+            .contains('Fax')
+            .click();
+
+        cy.contains('Download PDF')
+            .should('not.have.class', 'disabled')
+            .should('have.attr', 'href')
+            .and('match', /^blob:https?:\/\/[\S]+?\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    });
+});

--- a/cypress/integration/components/generator.spec.js
+++ b/cypress/integration/components/generator.spec.js
@@ -13,4 +13,27 @@ describe('Generator component', () => {
             .should('have.attr', 'href')
             .and('match', /^blob:https?:\/\/[\S]+?\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     });
+
+    it('did not load pdfworker for email', () => {
+        cy.window().then(win => {
+            expect(win.pdfWorker).to.be.undefined;
+        });
+    });
+
+    it('did load pdfworker for fax', () => {
+        cy.get('.request-transport-medium-chooser')
+            .contains('Fax')
+            .click();
+
+        cy.window().then(win => {
+            expect(win.pdfWorker).not.to.be.undefined;
+            // somehow it does not work with this: expect(win.pdfWorker).to.satisfy((o) => o instanceof Worker);
+            // "console.log(win.pdfWorker instanceof Worker)" logs false...
+            // time to 🦆 type...
+            expect(win.pdfWorker).respondTo('postMessage');
+            expect(win.pdfWorker).respondTo('terminate');
+            expect(win.pdfWorker).respondTo('onmessage');
+            expect(win.pdfWorker).respondTo('onerror');
+        });
+    });
 });

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -61,6 +61,7 @@
 {{ end }}
 
 {{ if .Site.Params.devMode }}
+<script>window.hugoDevMode = true;</script>
 <script>window.enableReactDevTools();</script>
 <script src="{{ "js/test-interface.gen.js" | absURL }}"></script>
 {{ end }}

--- a/src/Utility/RequestLetter.js
+++ b/src/Utility/RequestLetter.js
@@ -72,6 +72,10 @@ export default class RequestLetter {
     initiatePdfGeneration(filename) {
         if (!this.pdfWorker) {
             this.pdfWorker = new Worker(BASE_URL + 'js/pdfworker.gen.js');
+            if (process.env.NODE_ENV === 'development') {
+                // copy the worker to window if we are in a dev env to enable easy testing
+                window.pdfWorker = this.pdfWorker;
+            }
             this.pdfWorker.onmessage = message => {
                 if (this.pdf_callback) this.pdf_callback(message.data.blob_url, message.data.filename);
             };

--- a/src/Utility/RequestLetter.js
+++ b/src/Utility/RequestLetter.js
@@ -72,7 +72,7 @@ export default class RequestLetter {
     initiatePdfGeneration(filename) {
         if (!this.pdfWorker) {
             this.pdfWorker = new Worker(BASE_URL + 'js/pdfworker.gen.js');
-            if (process.env.NODE_ENV === 'development') {
+            if (window.hugoDevMode) {
                 // copy the worker to window if we are in a dev env to enable easy testing
                 window.pdfWorker = this.pdfWorker;
             }

--- a/src/Utility/RequestLetter.js
+++ b/src/Utility/RequestLetter.js
@@ -24,14 +24,6 @@ export default class RequestLetter {
 
         this.clearProps();
         this.setProps(props);
-
-        this.pdfWorker = new Worker(BASE_URL + 'js/pdfworker.gen.js');
-        this.pdfWorker.onmessage = message => {
-            if (this.pdf_callback) this.pdf_callback(message.data.blob_url, message.data.filename);
-        };
-        this.pdfWorker.onerror = error => {
-            rethrow(error, 'PdfWorker error');
-        };
     }
 
     setProps(props) {
@@ -78,6 +70,15 @@ export default class RequestLetter {
      * @param {String} filename
      */
     initiatePdfGeneration(filename) {
+        if (!this.pdfWorker) {
+            this.pdfWorker = new Worker(BASE_URL + 'js/pdfworker.gen.js');
+            this.pdfWorker.onmessage = message => {
+                if (this.pdf_callback) this.pdf_callback(message.data.blob_url, message.data.filename);
+            };
+            this.pdfWorker.onerror = error => {
+                rethrow(error, 'PdfWorker error');
+            };
+        }
         this.pdfWorker.postMessage({
             pdfdoc: { doc: this.toPdfDoc() },
             filename: filename


### PR DESCRIPTION
* I just moved the initialization of the pdfworker into the `initiatePdfGeneration`
* If the state changes to fax or letter the `pdfworker.js` is loaded
* Otherwise it is not loaded anymore, saving us some traffic and time