### PR TITLE
Fixes #352: Properly translate categories in the search

### DIFF
--- a/src/Components/SearchBar.js
+++ b/src/Components/SearchBar.js
@@ -44,7 +44,7 @@ if (Privacy.isAllowed(PRIVACY_ACTIONS.SEARCH)) {
 
         componentDidMount() {
             let options = {
-                query_by: this.props.query_by || 'name, runs, categories, web, slug, address, comments',
+                query_by: this.props.query_by || 'name, runs, web, slug, address, comments',
                 sort_by: 'sort-index:asc',
                 num_typos: 4,
                 per_page: this.props.numberOfHits || 5
@@ -86,7 +86,6 @@ if (Privacy.isAllowed(PRIVACY_ACTIONS.SEARCH)) {
 
                                 let name_hs = suggestion.highlights.filter(a => a.field === 'name');
                                 let runs_hs = suggestion.highlights.filter(a => a.field === 'runs');
-                                let cats_hs = suggestion.highlights.filter(a => a.field === 'categories');
 
                                 return (
                                     '<span><strong>' +
@@ -101,9 +100,7 @@ if (Privacy.isAllowed(PRIVACY_ACTIONS.SEARCH)) {
                                     (d.categories?.length
                                         ? '<br><span>' +
                                           t('categories', 'search') +
-                                          (cats_hs.length === 1 ? cats_hs[0].snippets : d.categories)
-                                              .map(c => t(c, 'categories'))
-                                              .join(', ') +
+                                          d.categories.map(c => t(c, 'categories')).join(', ') +
                                           '</span>'
                                         : '')
                                 );


### PR DESCRIPTION
This commit doesn't solve the issue per se but rather removes the mechanism that caused it as there was really no reason for that.

Let me explain: Previously, the search also queried the categories of the records. Therefore, `schokol` matched the category "school" (considering an allowed Levenshtein distance of 4).

For the matches, Typesense helpfully returns a "highlights" property where our category now looks like this: `<mark>school</mark>`.

The problem was that we were also feeding these "highlighted" results into our translate function which obviously didn't return anything as we don't have a translation for `<mark>school</mark>`.

This left me with two options: Either implement some annoying way to translate while still preserving the highlights or just drop searching in categories.*

The choice was quite obvious given that I don't really see any use for searching in the categories, **especially** the untranslated ones.

---

\*Technically, just removing `/<\/?mark>/` for the translation and then re-appending it around the whole translated word would have _probably_ been a good enough approximation and therefore another option.

  However, given that it really doesn't make sense to be able to search the categories anyway, this doesn't matter.