### PR TITLE
Replace remaining uses of GET parameters with URL fragments

### DIFF
--- a/content/de/contribute.md
+++ b/content/de/contribute.md
@@ -20,7 +20,7 @@ Vielen Dank, dass Du Dich über die Möglichkeiten zum Mitmachen informierst!
     </div>
     <div class="clearfix"></div>
     <!-- TODO: At some point, we will want to have proper landing page/better process for this. -->
-    <a class="button button-primary read-more-button" href="/suggest?type=new&for=cdb">Neues Unternehmen eintragen&nbsp;<span class="icon icon-arrow-right"></span></a>
+    <a class="button button-primary read-more-button" href="/suggest#!type=new&for=cdb">Neues Unternehmen eintragen&nbsp;<span class="icon icon-arrow-right"></span></a>
 </article>
 
 <article id="i18n" class="list-article icon-list-article">

--- a/content/en/contribute.md
+++ b/content/en/contribute.md
@@ -19,7 +19,7 @@ Thank you so much for looking into contributing to datarequests.org!
     </div>
     <div class="clearfix"></div>
     <!-- TODO: At some point, we will want to have proper landing page/better process for this. -->
-    <a class="button button-primary read-more-button" href="/suggest?type=new&for=cdb">Submit a new company&nbsp;<span class="icon icon-arrow-right"></span></a>
+    <a class="button button-primary read-more-button" href="/suggest#!type=new&for=cdb">Submit a new company&nbsp;<span class="icon icon-arrow-right"></span></a>
 </article>
 
 <article id="i18n" class="list-article icon-list-article">

--- a/content/fr/contribute.md
+++ b/content/fr/contribute.md
@@ -19,7 +19,7 @@ Merci beaucoup d'avoir cherché à contribuer à demandetesdonnees.fr !
     </div>
     <div class="clearfix"></div>
     <!-- TODO: At some point, we will want to have proper landing page/better process for this. -->
-    <a class="button button-primary read-more-button" href="/suggest?type=new&for=cdb">Proposer une nouvelle entreprise&nbsp;<span class="icon icon-arrow-right"></span></a>
+    <a class="button button-primary read-more-button" href="/suggest#!type=new&for=cdb">Proposer une nouvelle entreprise&nbsp;<span class="icon icon-arrow-right"></span></a>
 </article>
 
 <article id="i18n" class="list-article icon-list-article">

--- a/layouts/company/single.html
+++ b/layouts/company/single.html
@@ -23,10 +23,10 @@
     <div id="company-details">
         <div class="col100-mobile" style="float: right; text-align: right; padding: 0 0 15px 15px;">
             <a class="button button-primary button-small icon icon-letter"
-                href="{{ print ("generator" | absURL) "?company=" .Params.slug }}"
+                href="{{ print ("generator" | absURL) "#!company=" .Params.slug }}"
                 style="margin-bottom: 5px;">{{ T "cdb-send-request" }}</a><br>
             <a class="button button-secondary button-small icon icon-pencil"
-                href="{{ print ("suggest" | absURL) "?type=edit&for=cdb&slug=" .Params.slug }}">{{ T "cdb-suggest-change" }}</a>
+                href="{{ print ("suggest" | absURL) "#!type=edit&for=cdb&slug=" .Params.slug }}">{{ T "cdb-suggest-change" }}</a>
         </div>
 
         <p>{{ T "cdb-intro" . }}</p>
@@ -99,7 +99,7 @@
         {{ end }}
     </div>
     <div id="companies-help-needed" class="box box-info" style="margin-bottom: 20px;">
-        {{ T "cdb-help-needed" (dict "editUrl" (print ("suggest" | absURL) "?type=edit&for=cdb&slug=" .Params.slug) "newUrl" (print ("suggest" | absURL) "?type=new&for=cdb")) | safeHTML }}
+        {{ T "cdb-help-needed" (dict "editUrl" (print ("suggest" | absURL) "#!type=edit&for=cdb&slug=" .Params.slug) "newUrl" (print ("suggest" | absURL) "#!type=new&for=cdb")) | safeHTML }}
     </div>
 
     <!-- TODO: This is currently a very naive approach, mostly since we don't exactly have any data to do this better. We will want to improve this in the future. -->

--- a/src/Components/DonationWidget.js
+++ b/src/Components/DonationWidget.js
@@ -49,7 +49,7 @@ export default class DonationWidget extends preact.Component {
             .then((json) => {
                 switch (json?.status) {
                     case 'paid':
-                        window.location = `${BASE_URL}thanks?donation_reference=${json.reference}`;
+                        window.location = `${BASE_URL}thanks#!donation_reference=${json.reference}`;
                         break;
                     case 'failed':
                         flash(<FlashMessage type="error">{t('donation-failed', 'donation-widget')}</FlashMessage>);
@@ -225,7 +225,7 @@ export default class DonationWidget extends preact.Component {
                     id="donation-widget-thanks-button"
                     className="button button-primary"
                     style="float: right;"
-                    href={`${BASE_URL}thanks?donation_reference=${this.state.donation_reference}`}>
+                    href={`${BASE_URL}thanks#!donation_reference=${this.state.donation_reference}`}>
                     <Text id="thanks" />
                 </a>
                 <div className="clearfix"></div>
@@ -315,7 +315,7 @@ export default class DonationWidget extends preact.Component {
                         business: 'paypal@datenanfragen.de',
                         image_url: 'https://www.datenanfragen.de/img/logo-datenanfragen-ev.png',
                         no_shipping: 1,
-                        return: `${BASE_URL}thanks?donation_reference=${this.state.donation_reference}`,
+                        return: `${BASE_URL}thanks#!donation_reference=${this.state.donation_reference}`,
                         cancel_return: `${BASE_URL}donate`,
                         custom: this.state.donation_reference,
                     },


### PR DESCRIPTION
Not only did we switch a while ago, the old uses actually introduced regressions after our move to dattel due to the following, somewhat strange, redirect behaviour:

* /generator?company=a -> /generator/

Whereas:

* /generator#!company -> /generator/#!company=a

We will have to investigate the root cause of this issue separately but for now this is sort of a hotfix.