### PR TITLE
Clarify ITZ information in the footer

### DIFF
--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -843,7 +843,7 @@ footer {
         img.itz-logo {
             width: 100%;
             max-width: 300px;
-            margin-top: 15px;
+            margin-top: 5px;
 
             &:active,
             &:hover,

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -168,7 +168,7 @@
                     </ul>
                 </div>
                 <div class="col22 footer-col" style="font-size: 10px;
-margin-top: 20px;">
+margin-top: 5px;">
                     {{ if eq .Lang "de" }}Wir arbeiten transparent nach Kriterien der <a href="{{ "/verein/transparenz" | absURL }}"><img src="/img/logo-itz.svg" alt="ITZ (Initiative Transparente Zivilgesellschaft)" class="itz-logo"></a>{{ end }}
                 </div>
             </div>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -167,9 +167,8 @@
                         <li><a href="{{ T "footer-licenses-url" | absLangURL }}#license-notices">{{ T "footer-licenses" . }}</a></li>
                     </ul>
                 </div>
-                <div class="col22 footer-col" style="font-size: 10px;
-margin-top: 5px;">
-                    {{ if eq .Lang "de" }}Wir arbeiten transparent nach Kriterien der <a href="{{ "/verein/transparenz" | absURL }}"><img src="/img/logo-itz.svg" alt="ITZ (Initiative Transparente Zivilgesellschaft)" class="itz-logo"></a>{{ end }}
+                <div class="col22 footer-col" style="font-size: 10px;">
+                    {{ if eq .Lang "de" }}Wir arbeiten transparent nach Kriterien der <a href="{{ "/verein/transparenz" | absURL }}"><br><img src="/img/logo-itz.svg" alt="ITZ (Initiative Transparente Zivilgesellschaft)" class="itz-logo"></a>{{ end }}
                 </div>
             </div>
             <div class="clearfix"></div>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -167,7 +167,7 @@
                         <li><a href="{{ T "footer-licenses-url" | absLangURL }}#license-notices">{{ T "footer-licenses" . }}</a></li>
                     </ul>
                 </div>
-                <div class="col22 footer-col" style="font-size: 10px;">
+                <div class="col22 footer-col" style="font-size: 10px; margin-top: 20px;">
                     {{ if eq .Lang "de" }}Wir arbeiten transparent nach Kriterien der <a href="{{ "/verein/transparenz" | absURL }}"><br><img src="/img/logo-itz.svg" alt="ITZ (Initiative Transparente Zivilgesellschaft)" class="itz-logo"></a>{{ end }}
                 </div>
             </div>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -167,8 +167,9 @@
                         <li><a href="{{ T "footer-licenses-url" | absLangURL }}#license-notices">{{ T "footer-licenses" . }}</a></li>
                     </ul>
                 </div>
-                <div class="col22 footer-col">
-                    {{ if eq .Lang "de" }}<a href="{{ "/verein/transparenz" | absURL }}"><img src="/img/logo-itz.svg" alt="Logo der ITZ (Initiative Transparente Zivilgesellschaft)" class="itz-logo"></a>{{ end }}
+                <div class="col22 footer-col" style="font-size: 10px;
+margin-top: 20px;">
+                    {{ if eq .Lang "de" }}Wir arbeiten transparent nach Kriterien der <a href="{{ "/verein/transparenz" | absURL }}"><img src="/img/logo-itz.svg" alt="ITZ (Initiative Transparente Zivilgesellschaft)" class="itz-logo"></a>{{ end }}
                 </div>
             </div>
             <div class="clearfix"></div>


### PR DESCRIPTION
To avoid confusion, we want to clarify that we are not a subsidiary of the ITZ, but rather comply with their principles. The sentence I used was suggested by the ITZ and has therefore been cleared from trademark concerns.