### PR TITLE
Add open-source overview page translation to Portuguese, partially closes #436

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Nadja Rode
 Nathan Bonnemains
 Nishant Mittal
 Phoenix Déb
+Rafael Audibert
 Steffen Grundke
 WL
 wolffshots

--- a/content/pt/open-source.md
+++ b/content/pt/open-source.md
@@ -7,7 +7,7 @@
 
 <img id="open-source-humaaan" class="top-left-humaaan" style="margin-top: -70px;" src="/img/humaaans/open-source.svg">
 
-Código aberto está no coração do pedidodedados.org. Nós construímos o projeto do chão com a idéia de ser tão aberto quanto possível. Nossa [constituição]({{< ref "verein/constitution" >}}) nos obriga a publicar todo nosso conteúdo de forma livre e gratuita.
+Código aberto está no coração do pedidodedados.org. Nós construímos o projeto do chão com a idéia de ser tão aberto quanto possível. Nossa [constituição](https://www.datarequests.org/verein/constitution) nos obriga a publicar todo nosso conteúdo de forma livre e gratuita.
 
 Nós somos grandes proponentes do Código Aberto e acreditamos nele.
 

--- a/content/pt/open-source.md
+++ b/content/pt/open-source.md
@@ -2,16 +2,132 @@
 	"title": "Código aberto",
 	"type": "page",
 	"aliases": ["opensource", "oss", "foss"],
-	"heading": "<span style='text-align: center; font-family: monospace;'>pedidodedados.org <span class='color-red-600' title='amores'>❤</span> código aberto</span>"
+	"heading": "<span style='text-align: center; font-family: monospace;'>pedidodedados.org <span class='color-red-600' title='ama'>❤</span> Código aberto</span>"
 }
 
-<img id="open-source-humaaan" class="top-left-humaaan" src="/img/humaaans/open-source.svg">
+<img id="open-source-humaaan" class="top-left-humaaan" style="margin-top: -70px;" src="/img/humaaans/open-source.svg">
+
+Código aberto está no coração do pedidodedados.org. Nós construímos o projeto do chão com a idéia de ser tão aberto quanto possível. Nossa [constituição]({{< ref "verein/constitution" >}}) nos obriga a publicar todo nosso conteúdo de forma livre e gratuita.
+
+Nós somos grandes proponentes do Código Aberto e acreditamos nele.
+
+## Nossos repositórios de Código Aberto
+
+Aqui temos uma visão geral de repositórios que criamos - direta ou indiretamente - para pedidodedados.org. Eles são, claro, publicados com licensas livres. Nós lhe convidamos para dar uma olhada atrás da cortina, contribuir ou usar o nosso trabalho para seus próprios projetos! Nós aceitamos carinhosamente issues e pull requests através dos nossos repositórios.
+
+<!-- TODO: Adicionar novos repositórios quando fizer sentido. -->
+
+<article class="list-article icon-list-article">
+    <div class="col25 article-featured-image"><a href="https://github.com/datenanfragen/website"><img class="image" src="/card-icons/code.svg" alt="website"></a></div>
+    <div class="padded col75">
+        <a href="https://github.com/datenanfragen/website"><h1><code>website</code></h1></a>
+        <span class="license">Licença MIT</span>
+        <p class="description">
+			O website que você se encontra atualmente. Esse repositório não só contém o conteúdo mas também o código para o gerador, os controles de privacidade e mais.
+            <br>O site foi construído para ser primariamente estático, e utiliza Hugo e Preact.
+        </p>
+    </div>
+    <div class="clearfix"></div>
+    <a class="button button-primary read-more-button" href="https://github.com/datenanfragen/website">Ver repositório&nbsp;<span class="icon icon-arrow-right"></span></a>
+</article>
+
+<article class="list-article icon-list-article">
+    <div class="col25 article-featured-image"><a href="https://github.com/datenanfragen/data"><img class="image" src="/card-icons/database.svg" alt="data" style="width: 70%;"></a></div>
+    <div class="padded col75">
+        <a href="https://github.com/datenanfragen/data"><h1><code>dados</code></h1></a>
+        <span class="license">CC0</span>
+        <p class="description">
+			Os dados por trás do projeto. Ele inclui bancos de dados da nossa empresa e de autoridades supervisoras mas também exemplos de cartas.
+            <br>O repositório é estruturado como uma coleção de arquivos de textos sem estrutura que são legíveis tanto para humanos quanto para máquinas.
+        </p>
+    </div>
+    <div class="clearfix"></div>
+    <a class="button button-primary read-more-button" href="https://github.com/datenanfragen/data">Ver repositório&nbsp;<span class="icon icon-arrow-right"></span></a>
+</article>
+
+<article class="list-article icon-list-article">
+    <div class="col25 article-featured-image"><a href="https://github.com/datenanfragen/media"><img class="image" src="/card-icons/view.svg" alt="media"></a></div>
+    <div class="padded col75">
+        <a href="https://github.com/datenanfragen/media"><h1><code>media</code></h1></a>
+        <span class="license">Licença MIT</span>
+        <p class="description">
+			Nosso website utilizado para hospedar videos, media.datenanfragen.de. Esse repositório inclui o código fonte e os scripts utilizados para o site.
+        </p>
+    </div>
+    <div class="clearfix"></div>
+    <a class="button button-primary read-more-button" href="https://github.com/datenanfragen/media">Ver repositório&nbsp;<span class="icon icon-arrow-right"></span></a>
+</article>
+
+<article class="list-article icon-list-article">
+    <div class="col25 article-featured-image"><a href="https://github.com/datenanfragen/letter-generator"><img class="image" src="/card-icons/letter.svg" alt="letter-generator"></a></div>
+    <div class="padded col75">
+        <a href="https://github.com/datenanfragen/letter-generator"><h1><code>letter-generator (Gerador de Carta)</code></h1></a>
+        <span class="license">Licença MIT</span>
+        <p class="description">
+            Uma ferramente que lhe permite gerar cartas (em formato PDF ou texto não estruturado) de templates com layouts pré-definidos. Esse repositório inclui esses templates e os scripts necessários para renderizar as cartas a partir deles.
+        </p>
+    </div>
+    <div class="clearfix"></div>
+    <a class="button button-primary read-more-button" href="https://github.com/datenanfragen/letter-generator">Ver repositório&nbsp;<span class="icon icon-arrow-right"></span></a>
+</article>
+
+<article class="list-article icon-list-article">
+    <div class="col25 article-featured-image"><a href="https://github.com/datenanfragen/verein"><img class="image" src="/card-icons/group.svg" alt="verein"></a></div>
+    <div class="padded col75">
+        <a href="https://github.com/datenanfragen/verein"><h1><code>verein</code></h1></a>
+        <p class="description">
+            Nós também queremos gerenciar a ONG por trás desse projeto, Datenanfragen.de e.&nbsp;V., tão aberta e transparentemente quanto possível. Portanto, esse repositório contém documentos importantes com suas modificações.
+        </p>
+    </div>
+    <div class="clearfix"></div>
+    <a class="button button-primary read-more-button" href="https://github.com/datenanfragen/verein">Ver repositório&nbsp;<span class="icon icon-arrow-right"></span></a>
+</article>
+
+<article class="list-article icon-list-article">
+    <div class="col25 article-featured-image"><a href="https://github.com/zner0L/postcss-fonticons"><img class="image" src="/card-icons/icon-font.svg" alt="postcss-fonticons" style="width: 60%;"></a></div>
+    <div class="padded col75">
+        <a href="https://github.com/zner0L/postcss-fonticons"><h1><code>postcss-fonticons</code></h1></a>
+        <span class="license">Licença MIT</span>
+        <p class="description">
+            Um plugin para PostCSS que lhe permite criar sua fonte de ícones na hora, incluindo apenas os ícones que são realmente utilizados.
+            <br>Adaptado a partir do Plugin <a href="https://github.com/jantimon/iconfont-webpack-plugin">Plugin Icon Font Webpack</a>de Jan Nicklas.
+        </p>
+    </div>
+    <div class="clearfix"></div>
+    <a class="button button-primary read-more-button" href="https://github.com/zner0L/postcss-fonticons">Ver repositório&nbsp;<span class="icon icon-arrow-right"></span></a>
+</article>
+
+<article class="list-article icon-list-article">
+    <div class="col25 article-featured-image"><a href="https://github.com/datenanfragen/backend"><img class="image" src="/card-icons/speech-bubble.svg" alt="backend"></a></div>
+    <div class="padded col75">
+        <a href="https://github.com/datenanfragen/backend"><h1><code>backend</code></h1></a>
+        <span class="license">Licença MIT</span>
+        <p class="description">
+			O servidor que define os endpoints para as funcionalidades dinâmicas do website, como comentários, sugestões e doações.
+        </p>
+    </div>
+    <div class="clearfix"></div>
+    <a class="button button-primary read-more-button" href="https://github.com/datenanfragen/backend">Ver repositório&nbsp;<span class="icon icon-arrow-right"></span></a>
+</article>
+
+<a id="contributors"></a>
+## Contribuidores
+
+Um grandíssimo muito obrigado a todos que contribuem para pedidodedados.org! O projeto não seria possível sem você.
+
+<div class="box box-info" style="white-space: pre;">{{< authors >}}</div>
+
+Se você também já contribuiu, mas seu nome ainda não está na lista, lhe convidamos para adicioná-lo no [arquivo `AUTHORS`](https://github.com/datenanfragen/website/blob/master/AUTHORS).
 
 <a id="license-notices"></a>
-## Projetos de código aberto que usamos
+## Projetos de Código Aberto utilizados por nós
 
-A informação completa da licença para todos os projetos que usamos pode ser encontrada [aqui]({{< absURL "NOTICES.txt" >}}).
+Mantendo-se a par do espírito do Código Aberto, nós não só mantemos nossos próprios projetos de Código Aberto, como fazemos grande uso de outros para nosso trabalho.
+
+Nós somos orgulhosos de poder utilizar os seguintes projetos para esse website. Muito obrigado aos autores que decidiram possbilitar que outros utilizassem seu valioso trabalho!
+
+Você pode encontrar as licenças completas para todos projetos que usamos [aqui]({{< absURL "NOTICES.txt" >}}).
 
 <div class="box box-info attribution-box">
-    {{< attribution "por" >}}
+	{{< attribution "by" >}}
 </div>


### PR DESCRIPTION
Partially closes #436, with the translation of the open-source page to Portuguese 