### PR TITLE
Add alt tags to images

### DIFF
--- a/content/de/act/ada-health/index.md
+++ b/content/de/act/ada-health/index.md
@@ -26,7 +26,7 @@ Angesichts dieser Erkenntnisse raten wir Dir, vor einer Nutzung der Ada Health-A
 
 ## Wie kann ich meine Daten löschen lassen?
 
-<img class="offset-image offset-image-right" src="/card-icons/erase.svg" style="height: 150px; margin-right: -80px;">
+<img class="offset-image offset-image-right" src="/card-icons/erase.svg" style="height: 150px; margin-right: -80px;" alt="">
 
 Hast Du die App genutzt und warst Dir dieser Datenweitergabe vielleicht nicht bewusst? Zum Glück musst Du Dich nicht damit abfinden, dass Deine Gesundheitsdaten für immer bei diesen Anbietern bleiben. Die bereits erwähnte DSGVO gibt Dir nämlich eine ganze Reihe an [Rechten im Bezug auf Deine personenbezogenen Daten]({{< ref "your-gdpr-rights" >}}), darunter auch das Rechte, Deine Daten löschen zu lassen – das sogenannte [**Recht auf Vergessenwerden**]({{< ref "your-gdpr-rights" >}}#recht-auf-vergessenwerden).
 

--- a/content/de/act/deliveroo.md
+++ b/content/de/act/deliveroo.md
@@ -12,7 +12,7 @@ Hast Du den Lieferdienst in der Vergangenheit genutzt und Essen bestellt oder Di
 
 ## Wie fordere ich die Löschung meiner Daten?
 
-<img class="offset-image offset-image-right" src="/card-icons/erase.svg" style="height: 150px; margin-right: -100px;">
+<img class="offset-image offset-image-right" src="/card-icons/erase.svg" style="height: 150px; margin-right: -100px;" alt="">
 
 Hier kommt Dir die **DSGVO** (**Datenschutz-Grundverordnung**) zu Hilfe. Die gibt Dir nämlich eine ganze Reihe an [Rechten im Bezug auf Deine personenbezogenen Daten]({{< ref "your-gdpr-rights" >}}), darunter auch das Rechte, Deine Daten löschen zu lassen – das sogenannte [**Recht auf Vergessenwerden**]({{< ref "your-gdpr-rights" >}}#recht-auf-vergessenwerden).
 

--- a/content/de/blog/gdpr-cheat-sheet.md
+++ b/content/de/blog/gdpr-cheat-sheet.md
@@ -11,7 +11,7 @@
     "authors": [ "baltpeter" ]
 }
 
-<img class="offset-image offset-image-left" src="/card-icons/book-info.svg" style="height: 200px;">
+<img class="offset-image offset-image-left" src="/card-icons/book-info.svg" style="height: 200px;" alt="">
 
 Die DSGVO kann, wie jedes andere rechtliche Thema auch, auf den ersten Blick verwirrend wirken. Sie führt zahlreiche juristische Begriffe ein, die zum Verständnis der Regelungen wichtig sind.
 

--- a/content/de/blog/hacktoberfest-2019/index.md
+++ b/content/de/blog/hacktoberfest-2019/index.md
@@ -35,7 +35,7 @@ Wenn Du zusätzlich beim offiziellen Hacktoberfest teilnehmen möchtest, musst D
 
 ## Welche Repositories zählen für die Aktion?
 
-<img class="offset-image offset-image-right" src="/card-icons/code.svg" style="height: 150px; margin-right: -100px; margin-top: -50px;">
+<img class="offset-image offset-image-right" src="/card-icons/code.svg" style="height: 150px; margin-right: -100px; margin-top: -50px;" alt="">
 
 Wir werten Pull Requests in allen Repositories in der [Datenanfragen.de-Organisation auf GitHub](https://github.com/datenanfragen) sowie denen, die auf unserer [Open Source-Seite]({{< ref "/open-source" >}}) als unsere Repositories aufgeführt sind, als gültige Beiträge für die Aktion.  
 Wenn Du meinst, dass Dein Beitrag in einem anderen Repository dem Projekt hilft, frag bitte kurz per E-Mail an [hacktoberfest@datenanfragen.de](mailto:hacktoberfest@datenanfragen.de) nach, ob wir diesen Beitrag auch werten können.

--- a/content/de/blog/hacktoberfest-2020/index.md
+++ b/content/de/blog/hacktoberfest-2020/index.md
@@ -71,7 +71,7 @@ In Ausnahmefällen können wir auch weitere Repositories erlauben. Wenn Du meins
 
 ## Habt Ihr Vorschläge für Beiträge?
 
-<img class="offset-image offset-image-right" src="/card-icons/code.svg" style="height: 150px; margin-right: -100px; margin-top: -50px;">
+<img class="offset-image offset-image-right" src="/card-icons/code.svg" style="height: 150px; margin-right: -100px; margin-top: -50px;" alt="">
 
 Gerade wenn Du neu bei Datenanfragen.de bist, weißt Du wahrscheinlich gar nicht, wo Du anfangen kannst. Keine Sorge: Es gibt bei uns zahlreiche Bereiche, in denen Du mitmachen kannst – ganz unabhängig davon, ob Du Erfahrung mit Programmierung und Datenschutz hast oder nicht. Zum leichteren Einstieg haben wir Dir hier einmal ein paar Vorschläge zusammengestellt. Viele weitere Aufgaben findest Du in den Issues der jeweiligen Repositories. Wir freuen uns natürlich auch, wenn Du eigenen Ideen hast, was Du am Projekt verbessern könntest.
 

--- a/content/de/blog/supervisory-authorities/index.md
+++ b/content/de/blog/supervisory-authorities/index.md
@@ -16,7 +16,7 @@
     "blog_like": true
 }
 
-<img class="offset-image offset-image-left" src="/card-icons/authority.svg" style="height: 200px;">
+<img class="offset-image offset-image-left" src="/card-icons/authority.svg" style="height: 200px;" alt="">
 
 Die Datenschutz-Aufsichtsbehörden sind eine wichtige Instanz für den Datenschutz. Sie sollen als unabhängige Stellen die Einhaltung der Datenschutzgesetze, insbesondere der DSGVO, sicherstellen.
 
@@ -41,7 +41,7 @@ Dabei ist zu beachten, dass dieser Grundsatz nur regelt, mit welcher Behörde Du
 <a id="finder"></a>
 ## An welche Datenschutz-Aufsichtsbehörde sollte ich mich wenden?
 
-<img class="offset-image offset-image-right" src="/img/humaaans/question-1.svg" style="height: 350px;">
+<img class="offset-image offset-image-right" src="/img/humaaans/question-1.svg" style="height: 350px;" alt="">
 
 Wenn Du nun also eine konkrete Beschwerde oder sonstige Frage hast und die Hilfe einer Datenschutz-Aufsichtsbehörde in Anspruch nehmen möchtest, bleibt die Frage, an welche Du die wenden solltest. Grundsätzlich wird Dich auch eine „falsche“ Behörde im Zweifelsfall an die richtige weiterleiten, aber es ist natürlich einfacher und schneller, wenn Du direkt die Behörde erwischst, die für Dich zuständig ist.
 

--- a/content/de/open-source.md
+++ b/content/de/open-source.md
@@ -5,7 +5,7 @@
 	"heading": "<span style='text-align: center; font-family: monospace;'>Datenanfragen.de <span class='color-red-600' title='liebt'>❤</span> Open Source</span>"
 }
 
-<img id="open-source-humaaan" class="top-left-humaaan" src="/img/humaaans/open-source.svg">
+<img id="open-source-humaaan" class="top-left-humaaan" src="/img/humaaans/open-source.svg" alt="">
 
 Open Source steht im Kern von Datenanfragen.de. Wir haben das Projekt von Grund auf konzipiert, so offen wie möglich zu sein. So verpflichtet uns nicht zuletzt unsere [Satzung]({{< ref "verein/constitution" >}}), unsere Inhalte unter freien Lizenzen zur Verfügung zu stellen.
 

--- a/content/de/thanks.md
+++ b/content/de/thanks.md
@@ -4,7 +4,7 @@
     "aliases": ["verein/thanks", "danke", "verein/danke"]
 }
 
-<img class="top-right-humaaan" src="/img/humaaans/thanks.svg">
+<img class="top-right-humaaan" src="/img/humaaans/thanks.svg" alt="">
 
 Vielen herzlichen Dank für Deine Spende! Damit hilfst Du uns ungemein, unsere Webseite in Zukunft weiter für alle kostenlos anbieten zu können und vor allem neue Projekte für den Datenschutz in Europa zu starten. Was genau mit Deiner Spende passiert, kannst du in unseren [Jahresberichten]({{< ref "verein/transparency" >}}) nachlesen. 
 

--- a/content/de/thanks.md
+++ b/content/de/thanks.md
@@ -4,7 +4,7 @@
     "aliases": ["verein/thanks", "danke", "verein/danke"]
 }
 
-<img class="top-right-humaaan" src="/img/humaaans/thanks.svg" alt="">
+<img class="top-right-humaaan" src="/img/humaaans/thanks.svg" alt="Ein großes Herz schwebt neben einer Person.">
 
 Vielen herzlichen Dank für Deine Spende! Damit hilfst Du uns ungemein, unsere Webseite in Zukunft weiter für alle kostenlos anbieten zu können und vor allem neue Projekte für den Datenschutz in Europa zu starten. Was genau mit Deiner Spende passiert, kannst du in unseren [Jahresberichten]({{< ref "verein/transparency" >}}) nachlesen. 
 

--- a/content/de/verein/transparency.md
+++ b/content/de/verein/transparency.md
@@ -5,7 +5,7 @@
     "type": "page"
 }
 
-<a href="https://www.transparency.de/mitmachen/initiative-transparente-zivilgesellschaft/" class="no-link-decoration"><img src="/img/logo-itz.svg" style="float: right; width: 40%; min-width: 200px; padding: 5px;"></a>
+<a href="https://www.transparency.de/mitmachen/initiative-transparente-zivilgesellschaft/" class="no-link-decoration"><img src="/img/logo-itz.svg" style="float: right; width: 40%; min-width: 200px; padding: 5px;" alt="Logo der Initiative Transparente Zivilgesellschaft"></a>
 
 Damit Du uns vertrauen kannst, haben wir uns verpflichtet, unsere Abläufe, Finanzen und Entscheidungen so transparent wie möglich zu machen. Wir sind deshalb Teil der [Initiative Transparente Zivilgesellschaft](https://www.transparency.de/mitmachen/initiative-transparente-zivilgesellschaft/), die uns stichprobenartig kontrollieren kann und dafür sorgt, dass unser Versprechen zur transparenten Geschäftsführung kein leeres bleibt. Auf dieser Seite sind nun alle wichtigen Informationen zusammengefasst, die wir im Rahmen unseres Transparenzberichts veröffentlichen.
 

--- a/content/en/blog/gdpr-cheat-sheet.md
+++ b/content/en/blog/gdpr-cheat-sheet.md
@@ -11,7 +11,7 @@
     "authors": [ "baltpeter", "xeluna" ]
 }
 
-<img class="offset-image offset-image-left" src="/card-icons/book-info.svg" style="height: 200px;">
+<img class="offset-image offset-image-left" src="/card-icons/book-info.svg" style="height: 200px;" alt="">
 
 At first glance, the GDPR can appear confusing like any other legal topic. It introduces numerous legal terms that are vital for understanding the regulations.
 

--- a/content/en/blog/hacktoberfest-2019/index.md
+++ b/content/en/blog/hacktoberfest-2019/index.md
@@ -34,7 +34,7 @@ If you also want to participate in the official Hacktoberfest, you will need to 
 
 ## Which repositories qualify?
 
-<img class="offset-image offset-image-right" src="/card-icons/code.svg" style="height: 150px; margin-right: -100px; margin-top: -50px;">
+<img class="offset-image offset-image-right" src="/card-icons/code.svg" style="height: 150px; margin-right: -100px; margin-top: -50px;" alt="">
 
 We will count pull requests to all repositories in the [datenanfragen organization on GitHub](https://github.com/datenanfragen) as well as those to our repositories listed on our [open source page]({{< ref "/open-source" >}}).  
 If you think your contribution to another repository will also help our project, please shoot us an email at [hacktoberfest@datenanfragen.de](mailto:hacktoberfest@datenanfragen.de) to ask if we can count that.

--- a/content/en/blog/hacktoberfest-2020/index.md
+++ b/content/en/blog/hacktoberfest-2020/index.md
@@ -71,7 +71,7 @@ We may also accept additional repositories. If you think that your contribution 
 
 ## Do you have any suggestions on what to contribute?
 
-<img class="offset-image offset-image-right" src="/card-icons/code.svg" style="height: 150px; margin-right: -100px; margin-top: -50px;">
+<img class="offset-image offset-image-right" src="/card-icons/code.svg" style="height: 150px; margin-right: -100px; margin-top: -50px;" alt="">
 
 If you're new to Datenanfragen.de, you may be a little overwhelmed and don't know where to start. Don't worry: There are numerous areas in which you can participate—regardless of whether you have experience with programming and data protection or not. To make it easier for you to get started, we have put together a few suggestions here. You can find many more tasks in the issues of the respective repositories. Of course we also welcome your own ideas on how you could improve the project.
 

--- a/content/en/blog/supervisory-authorities/index.md
+++ b/content/en/blog/supervisory-authorities/index.md
@@ -15,7 +15,7 @@
     "blog_like": true
 }
 
-<img class="offset-image offset-image-left" src="/card-icons/authority.svg" style="height: 200px;">
+<img class="offset-image offset-image-left" src="/card-icons/authority.svg" style="height: 200px;" alt="">
 
 The supervisory data protection authorities are an important institution for data protection. As independent bodies, their task is to ensure compliance with data protection laws, in particular the GDPR.
 
@@ -40,7 +40,7 @@ It should be noted that this principle only regulates which authority you contac
 <a id="finder"></a>
 ## Which supervisory authority should I contact?
 
-<img class="offset-image offset-image-right" src="/img/humaaans/question-1.svg" style="height: 350px;">
+<img class="offset-image offset-image-right" src="/img/humaaans/question-1.svg" style="height: 350px;" alt="">
 
 So, if you have a complaint or other question and would like to seek the help of a supervisory data protection authority, the question remains as to which one you should contact. In general, even the “wrong” authority will forward you to the right one, but it is of course easier and faster if you contact the correct one directly.
 

--- a/content/en/open-source.md
+++ b/content/en/open-source.md
@@ -5,7 +5,7 @@
 	"heading": "<span style='text-align: center; font-family: monospace;'>datarequests.org <span class='color-red-600' title='loves'>❤</span> Open Source</span>"
 }
 
-<img id="open-source-humaaan" class="top-left-humaaan" style="margin-top: -70px;" src="/img/humaaans/open-source.svg">
+<img id="open-source-humaaan" class="top-left-humaaan" style="margin-top: -70px;" src="/img/humaaans/open-source.svg" alt="">
 
 Open Source is at the very core of datarequests.org. We have designed the project from the ground up to be as open as possible. Our [constitution]({{< ref "verein/constitution" >}}) requires us to publish our content under free licenses.
 

--- a/content/en/thanks.md
+++ b/content/en/thanks.md
@@ -4,7 +4,7 @@
     "aliases": ["verein/thanks"]
 }
 
-<img class="top-right-humaaan" src="/img/humaaans/thanks.svg">
+<img class="top-right-humaaan" src="/img/humaaans/thanks.svg" alt="">
 
 Thank you so much for your donation! It really helps us continue running our website free for everyone in the future and also to start new project for data protection in Europe. You can read about what exactly will happen with your donation in our [yearly reports]({{< ref "verein/transparency" >}}).
 

--- a/content/en/thanks.md
+++ b/content/en/thanks.md
@@ -4,7 +4,7 @@
     "aliases": ["verein/thanks"]
 }
 
-<img class="top-right-humaaan" src="/img/humaaans/thanks.svg" alt="">
+<img class="top-right-humaaan" src="/img/humaaans/thanks.svg" alt="A big heart floating next to a person.">
 
 Thank you so much for your donation! It really helps us continue running our website free for everyone in the future and also to start new project for data protection in Europe. You can read about what exactly will happen with your donation in our [yearly reports]({{< ref "verein/transparency" >}}).
 

--- a/content/en/verein/transparency.md
+++ b/content/en/verein/transparency.md
@@ -3,7 +3,7 @@
     "type": "page"
 }
 
-<a href="https://www.transparency.de/mitmachen/initiative-transparente-zivilgesellschaft/" class="no-link-decoration"><img src="/img/logo-itz.svg" style="float: right; width: 40%; min-width: 200px; padding: 5px;" alt="Initiative Transparente Zivilgesellschaft logo"></a>
+<a href="https://www.transparency.de/mitmachen/initiative-transparente-zivilgesellschaft/" class="no-link-decoration"><img src="/img/logo-itz.svg" style="float: right; width: 40%; min-width: 200px; padding: 5px;" alt="Logo of the Initiative for a Transparent Civil Society, with the German text “Initiative Transparente Zivilgesellschaft”"></a>
 
 In order for you to be able to trust us, we pledged to be as transparent as possible about our procedures, finances and decisions. Because of that, we have joined the [Initiative for a Transparent Civil Society](https://www.transparency.de/mitmachen/initiative-transparente-zivilgesellschaft/), an initiative by the German branch of Transparency International, which is allowed to audit us on a sample basis. They ensure that we will keep our promise of transparent management. On this page we summarized all the important information that we publish as part of that.
 

--- a/content/en/verein/transparency.md
+++ b/content/en/verein/transparency.md
@@ -3,7 +3,7 @@
     "type": "page"
 }
 
-<a href="https://www.transparency.de/mitmachen/initiative-transparente-zivilgesellschaft/" class="no-link-decoration"><img src="/img/logo-itz.svg" style="float: right; width: 40%; min-width: 200px; padding: 5px;"></a>
+<a href="https://www.transparency.de/mitmachen/initiative-transparente-zivilgesellschaft/" class="no-link-decoration"><img src="/img/logo-itz.svg" style="float: right; width: 40%; min-width: 200px; padding: 5px;" alt="Initiative Transparente Zivilgesellschaft logo"></a>
 
 In order for you to be able to trust us, we pledged to be as transparent as possible about our procedures, finances and decisions. Because of that, we have joined the [Initiative for a Transparent Civil Society](https://www.transparency.de/mitmachen/initiative-transparente-zivilgesellschaft/), an initiative by the German branch of Transparency International, which is allowed to audit us on a sample basis. They ensure that we will keep our promise of transparent management. On this page we summarized all the important information that we publish as part of that.
 

--- a/content/fr/blog/supervisory-authorities/index.md
+++ b/content/fr/blog/supervisory-authorities/index.md
@@ -16,7 +16,7 @@
     "blog_like": true
 }
 
-<img class="offset-image offset-image-left" src="/card-icons/authority.svg" style="height: 200px;">
+<img class="offset-image offset-image-left" src="/card-icons/authority.svg" style="height: 200px;" alt="">
 
 Les autorités de contrôle de la protection des données sont une institution importante pour la protection des données. En tant que structures indépendantes, elles ont pour mission de veiller au respect des lois sur la protection des données, en particulier le RGPD.
 
@@ -41,7 +41,7 @@ Il convient de noter que ce principe régit uniquement l'autorité à laquelle t
 <a id="finder"></a>
 ## Quelle autorité de contrôle dois-je contacter ?
 
-<img class="offset-image offset-image-right" src="/img/humaaans/question-1.svg" style="height: 350px;">
+<img class="offset-image offset-image-right" src="/img/humaaans/question-1.svg" style="height: 350px;" alt="">
 
 Ainsi, si tu as une réclamation ou une autre question et que tu souhaites demander l'aide d'une autorité de contrôle de la protection des données, la question reste de savoir à laquelle tu dois t'adresser. En général, même la « mauvaise » autorité te redirigera vers la bonne, mais il est bien sûr plus facile et plus rapide de contacter directement la bonne.
 

--- a/content/fr/open-source.md
+++ b/content/fr/open-source.md
@@ -5,7 +5,7 @@
 	"heading": "<span style='text-align: center; font-family: monospace;'>demandetesdonnees.fr <span class='color-red-600' title='aime'>❤</span> l'Open Source</span>"
 }
 
-<img id="open-source-humaaan" class="top-left-humaaan" style="margin-top: -70px;" src="/img/humaaans/open-source.svg">
+<img id="open-source-humaaan" class="top-left-humaaan" style="margin-top: -70px;" src="/img/humaaans/open-source.svg" alt="">
 
 L'Open Source est au cœur même de demandetesdonnees.fr. Nous avons conçu ce projet à partir de rien pour qu'il soit le plus ouvert possible. Notre [constitution]({{< ref "verein/constitution" >}}) nous engage à publier notre contenu sous licence libre.
 

--- a/content/fr/thanks.md
+++ b/content/fr/thanks.md
@@ -4,7 +4,7 @@
     "aliases": ["verein/thanks"]
 }
 
-<img class="top-right-humaaan" src="/img/humaaans/thanks.svg">
+<img class="top-right-humaaan" src="/img/humaaans/thanks.svg" alt="">
 
 Merci beaucoup pour ton don ! Cela nous aide vraiment à continuer à faire fonctionner notre site Web gratuitement pour tous à l'avenir et à lancer de nouveaux projets pour la protection des données en Europe. Tu peux savoir exactement où ton argent est allé dans nos [rapports annuels]({{< ref "verein/transparency" >}}).
 

--- a/content/pt/open-source.md
+++ b/content/pt/open-source.md
@@ -5,7 +5,7 @@
 	"heading": "<span style='text-align: center; font-family: monospace;'>pedidodedados.org <span class='color-red-600' title='ama'>❤</span> Código aberto</span>"
 }
 
-<img id="open-source-humaaan" class="top-left-humaaan" style="margin-top: -70px;" src="/img/humaaans/open-source.svg">
+<img id="open-source-humaaan" class="top-left-humaaan" style="margin-top: -70px;" src="/img/humaaans/open-source.svg" alt="">
 
 Código aberto está no coração do pedidodedados.org. Nós construímos o projeto do chão com a idéia de ser tão aberto quanto possível. Nossa [constituição](https://www.datarequests.org/verein/constitution) nos obriga a publicar todo nosso conteúdo de forma livre e gratuita.
 

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -3,7 +3,7 @@
 
 {{ define "main" }}
 <main>
-    <img id="404-artwork" src="/img/404_artwork.svg" style="display: block; max-height: 500px; margin: auto; margin-bottom: 25px;" alt="">
+    <img id="404-artwork" src="/img/404_artwork.svg" style="display: block; max-height: 500px; margin: auto; margin-bottom: 25px;" alt="{{ T "404-alt" }}">
 
     <div class="box box-warning">{{ T "404-body" | safeHTML }}</div>
 </main>

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -3,7 +3,7 @@
 
 {{ define "main" }}
 <main>
-    <img id="404-artwork" src="/img/404_artwork.svg" style="display: block; max-height: 500px; margin: auto; margin-bottom: 25px;">
+    <img id="404-artwork" src="/img/404_artwork.svg" style="display: block; max-height: 500px; margin: auto; margin-bottom: 25px;" alt="">
 
     <div class="box box-warning">{{ T "404-body" | safeHTML }}</div>
 </main>

--- a/layouts/verein/list.html
+++ b/layouts/verein/list.html
@@ -4,7 +4,7 @@
         <div class="container">
             <div class="col33">
                 <div class="verein-home-card">
-                    <div class="top-icon"><img src="{{ "card-icons/check.svg" | absURL }}"></div>
+                    <div class="top-icon"><img src="{{ "card-icons/check.svg" | absURL }}" alt=""></div>
                     <h2>{{ T "verein-home-card-mission-heading" }}</h2>
                     <p>{{ T "verein-home-card-mission-content" | safeHTML }}</p>
                     <a href="{{ ref . "verein/mission-statement" }}" class="button button-secondary">{{ T "verein-home-card-mission-button" }}</span></a>
@@ -12,7 +12,7 @@
             </div>
             <div class="col33" style="padding-top: 0;">
                 <div class="verein-home-card">
-                    <div class="top-icon" style="font-size: 35px;"><img src="{{ "card-icons/money.svg" | absURL }}"></div>
+                    <div class="top-icon" style="font-size: 35px;"><img src="{{ "card-icons/money.svg" | absURL }}" alt=""></div>
                     <h2>{{ T "verein-home-card-donate-heading" }}</h2>
                     <p>{{ T "verein-home-card-donate-content" }}</p>
                     <a href="{{ ref . "donate" }}" class="button button-primary">{{ T "verein-home-card-donate-button" }}</a>
@@ -20,7 +20,7 @@
             </div>
             <div class="col33 ">
                 <div class="verein-home-card">
-                    <div class="top-icon" style="font-size: 38px;"><img src="{{ "card-icons/group.svg" | absURL }}"></div>
+                    <div class="top-icon" style="font-size: 38px;"><img src="{{ "card-icons/group.svg" | absURL }}" alt=""></div>
                     <h2>{{ T "verein-home-card-join-heading" }}</h2>
                     <p>{{ T "verein-home-card-join-content" }}</p>
                     <a href="{{ ref . "verein/become-a-member" }}" class="button button-secondary">{{ T "verein-home-card-join-button" }}</a>

--- a/layouts/verein/list.html
+++ b/layouts/verein/list.html
@@ -4,7 +4,7 @@
         <div class="container">
             <div class="col33">
                 <div class="verein-home-card">
-                    <div class="top-icon"><img src="{{ "card-icons/check.svg" | absURL }}" alt=""></div>
+                    <div class="top-icon"><img src="{{ "card-icons/check.svg" | absURL }}" alt="Ein Häkchen in einem Kasten."></div>
                     <h2>{{ T "verein-home-card-mission-heading" }}</h2>
                     <p>{{ T "verein-home-card-mission-content" | safeHTML }}</p>
                     <a href="{{ ref . "verein/mission-statement" }}" class="button button-secondary">{{ T "verein-home-card-mission-button" }}</span></a>
@@ -12,7 +12,7 @@
             </div>
             <div class="col33" style="padding-top: 0;">
                 <div class="verein-home-card">
-                    <div class="top-icon" style="font-size: 35px;"><img src="{{ "card-icons/money.svg" | absURL }}" alt=""></div>
+                    <div class="top-icon" style="font-size: 35px;"><img src="{{ "card-icons/money.svg" | absURL }}" alt="Ein Euro-Zeichen in einem Kreis."></div>
                     <h2>{{ T "verein-home-card-donate-heading" }}</h2>
                     <p>{{ T "verein-home-card-donate-content" }}</p>
                     <a href="{{ ref . "donate" }}" class="button button-primary">{{ T "verein-home-card-donate-button" }}</a>
@@ -20,7 +20,7 @@
             </div>
             <div class="col33 ">
                 <div class="verein-home-card">
-                    <div class="top-icon" style="font-size: 38px;"><img src="{{ "card-icons/group.svg" | absURL }}" alt=""></div>
+                    <div class="top-icon" style="font-size: 38px;"><img src="{{ "card-icons/group.svg" | absURL }}" alt="Ein Umrisse von drei Portraits."></div>
                     <h2>{{ T "verein-home-card-join-heading" }}</h2>
                     <p>{{ T "verein-home-card-join-content" }}</p>
                     <a href="{{ ref . "verein/become-a-member" }}" class="button button-secondary">{{ T "verein-home-card-join-button" }}</a>

--- a/layouts/verein/list.html
+++ b/layouts/verein/list.html
@@ -20,7 +20,7 @@
             </div>
             <div class="col33 ">
                 <div class="verein-home-card">
-                    <div class="top-icon" style="font-size: 38px;"><img src="{{ "card-icons/group.svg" | absURL }}" alt="Ein Umrisse von drei Portraits."></div>
+                    <div class="top-icon" style="font-size: 38px;"><img src="{{ "card-icons/group.svg" | absURL }}" alt="Umrisse von drei Personen."></div>
                     <h2>{{ T "verein-home-card-join-heading" }}</h2>
                     <p>{{ T "verein-home-card-join-content" }}</p>
                     <a href="{{ ref . "verein/become-a-member" }}" class="button button-secondary">{{ T "verein-home-card-join-button" }}</a>

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -114,7 +114,7 @@
         "noscript-wizard": "An dieser Stelle befände sich ein mit JavaScript generierter Wizard, zur Erstellung von Anfragen auf Datenauskunft. Die Erstellung der Anfragen benötigt JavaScript. Du kannst die Seite benutzen, ohne JavaScript zu aktiveren, hast dann aber leider nur Zugriff auf eingeschränkte Funktionen. Der Code wird keine Daten an andere Server weiterleiten, wenn Du das nicht möchtest. Wenn Du die Webseite im vollem Umfang nutzen möchtest musst du JavaScript im Browser aktivieren oder eine Ausnahme in Deine Blocker hinzufügen. Sollte es dann immer noch nicht funktionieren, schreib uns eine E-Mail an <a href='mailto:dev@datenanfragen.de'>dev@datenanfragen.de</a>.",
         "404-title": "Fehler 404: Seite nicht gefunden",
         "404-body": "Leider existiert die gesuchte Seite auf diesem Server nicht. Vielleicht hast du dich ja einfach in der URL vertippt? Falls der Fehler wieder auftritt, hinterlasse uns doch einen Hinweis auf unserer E-Mail-Adresse <a href='mailto:dev@datenanfragen.de'>dev@datenanfragen.de</a> oder schreib in unseren <a href='https://github.com/datenanfragen/website/issues/new'>Issue-Tracker</a>.",
-        "404-alt": "Eine Person die auf dem 0 eines großen 404-Schildes sitzt. Sie hält ein Buch, in dem eine Seite fehlt.",
+        "404-alt": "Eine Person die auf der 0 eines großen 404-Schildes sitzt. Sie hält ein Buch, in dem eine Seite fehlt.",
         "press-no-releases": "Es wurden noch keine Pressemitteilungen auf Deutsch veröffentlicht.",
         "lic-cc-by-40": "Creative Commons Namensnennung 4.0 International Lizenz",
         "lic-url-cc-by-40": "https://creativecommons.org/licenses/by/4.0/deed.de",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -114,6 +114,7 @@
         "noscript-wizard": "An dieser Stelle befände sich ein mit JavaScript generierter Wizard, zur Erstellung von Anfragen auf Datenauskunft. Die Erstellung der Anfragen benötigt JavaScript. Du kannst die Seite benutzen, ohne JavaScript zu aktiveren, hast dann aber leider nur Zugriff auf eingeschränkte Funktionen. Der Code wird keine Daten an andere Server weiterleiten, wenn Du das nicht möchtest. Wenn Du die Webseite im vollem Umfang nutzen möchtest musst du JavaScript im Browser aktivieren oder eine Ausnahme in Deine Blocker hinzufügen. Sollte es dann immer noch nicht funktionieren, schreib uns eine E-Mail an <a href='mailto:dev@datenanfragen.de'>dev@datenanfragen.de</a>.",
         "404-title": "Fehler 404: Seite nicht gefunden",
         "404-body": "Leider existiert die gesuchte Seite auf diesem Server nicht. Vielleicht hast du dich ja einfach in der URL vertippt? Falls der Fehler wieder auftritt, hinterlasse uns doch einen Hinweis auf unserer E-Mail-Adresse <a href='mailto:dev@datenanfragen.de'>dev@datenanfragen.de</a> oder schreib in unseren <a href='https://github.com/datenanfragen/website/issues/new'>Issue-Tracker</a>.",
+        "404-alt": "Eine Person die auf dem 0 eines großen 404-Schildes sitzt. Sie hält ein Buch, in dem eine Seite fehlt.",
         "press-no-releases": "Es wurden noch keine Pressemitteilungen auf Deutsch veröffentlicht.",
         "lic-cc-by-40": "Creative Commons Namensnennung 4.0 International Lizenz",
         "lic-url-cc-by-40": "https://creativecommons.org/licenses/by/4.0/deed.de",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -116,6 +116,7 @@
         "press-no-releases": "At this time there are no press releases in English.",
         "404-title": "Error 404: Page not found",
         "404-body": "The page you were looking for sadly doesn't exist on this server. Maybe you just have a typo in the URL? If the error persists, perhaps notify us via our email <a href='mailto:dev@datenanfragen.de'>dev@datenanfragen.de</a> or submit an issue in our <a href='https://github.com/datenanfragen/website/issues/new'>issue tracker</a>.",
+        "404-alt": "A person sitting on the 0 of a big 404 sign. They hold a book with a missing page.",
         "lic-cc-by-40": "Creative Commons Attribution 4.0 International License",
         "lic-url-cc-by-40": "https://creativecommons.org/licenses/by/4.0/deed.en",
         "lic-cc-by-nd-40": "Creative Commons Attribution-NoDerivatives 4.0 International License",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -116,7 +116,7 @@
         "press-no-releases": "At this time there are no press releases in English.",
         "404-title": "Error 404: Page not found",
         "404-body": "The page you were looking for sadly doesn't exist on this server. Maybe you just have a typo in the URL? If the error persists, perhaps notify us via our email <a href='mailto:dev@datenanfragen.de'>dev@datenanfragen.de</a> or submit an issue in our <a href='https://github.com/datenanfragen/website/issues/new'>issue tracker</a>.",
-        "404-alt": "A person sitting on the 0 of a big 404 sign. They hold a book with a missing page.",
+        "404-alt": "A person sitting on the 0 of a big 404 sign. They are holding a book with a missing page.",
         "lic-cc-by-40": "Creative Commons Attribution 4.0 International License",
         "lic-url-cc-by-40": "https://creativecommons.org/licenses/by/4.0/deed.en",
         "lic-cc-by-nd-40": "Creative Commons Attribution-NoDerivatives 4.0 International License",


### PR DESCRIPTION
> Omitting alt altogether indicates that the image is a key part of the content and no textual equivalent is available. Setting this attribute to an empty string (alt="") indicates that this image is not a key part of the content (it’s decoration or a tracking pixel), and that non-visual browsers may omit it from rendering. Visual browsers will also hide the broken image icon if the alt is empty and the image failed to display."

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img