### PR TITLE
Disable Percy for now

### DIFF
--- a/cypress/integration/use-cases/percy.spec.js
+++ b/cypress/integration/use-cases/percy.spec.js
@@ -5,7 +5,7 @@ function snap(url) {
     cy.percySnapshot(url);
 }
 
-describe('Visual diffs using Percy', async () => {
+describe.skip('Visual diffs using Percy', async () => {
     it('Snapshots', async () => {
         skipOn(isOn('production'));
 


### PR DESCRIPTION
It's currently broken anyway (#369) and since #518, the scheduled production test keeps failing (which seems to be related to Percy).