### PR TITLE
Add request form spanish translations

### DIFF
--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -203,6 +203,12 @@
         "download-pdf-again": "Descargar PDF de nuevo"
     },
     "requests": {
+        "letter-subject-erasure": "Solicitud de supresión de datos personales de acuerdo con el Art. 17 del RGPD",
+        "letter-subject-access": "Solicitud de acceso a datos personales según Art. 15 del RGPD",
+        "letter-subject-rectification": "Solicitud de rectificación de datos personales según Art. 16 del RGPD",
+        "letter-subject-objection": "Objeción al marketing directo según el Art. 21 (2) del RGPD",
+        "my-reference": "Mi referencia",
+        "concerns": "Concierne",
         "date": "Fecha",
         "name": "Nombre",
         "birthdate": "Fecha de nacimiento",


### PR DESCRIPTION
Certain fields were showing up as 'null' when sending a request whose preferred language was 'es' 

Translations were successfully tested locally on dev environment 