### PR TITLE
Fixes #182: Don't remember clearing the signature in the generator  

### DIFF
--- a/src/Components/Generator/SignatureInput.js
+++ b/src/Components/Generator/SignatureInput.js
@@ -71,16 +71,18 @@ export default class SignatureInput extends Component {
                 const top = (this.canvas.height - img.height) / 2;
                 this.clear();
                 this.context.drawImage(img, left, top);
-                this.setState({
-                    isEmpty: false,
-                    cropArea: {
-                        top,
-                        bottom: img.height + top,
-                        left,
-                        right: img.width + left,
+                this.setState(
+                    {
+                        isEmpty: false,
+                        cropArea: {
+                            top,
+                            bottom: img.height + top,
+                            left,
+                            right: img.width + left,
+                        },
                     },
-                });
-                this.handleChange();
+                    () => this.handleChange()
+                );
             };
             img.src = signature.value;
         }
@@ -108,8 +110,7 @@ export default class SignatureInput extends Component {
     clear() {
         if (this.state.isEmpty) return;
         this.context.clearRect(0, 0, this.state.width, this.state.height);
-        this.setState({ isEmpty: true, cropArea: this.initialCropArea });
-        this.handleChange();
+        this.setState({ isEmpty: true, cropArea: this.initialCropArea }, () => this.handleChange());
     }
 
     render() {

--- a/src/Components/RequestGeneratorBuilder.js
+++ b/src/Components/RequestGeneratorBuilder.js
@@ -557,7 +557,8 @@ export default class RequestGeneratorBuilder extends Component {
     storeRequest = () => {
         if (Privacy.isAllowed(PRIVACY_ACTIONS.SAVE_ID_DATA)) {
             this.savedIdData.storeArray(this.state.request.id_data);
-            this.savedIdData.storeSignature(this.state.request.signature);
+            // Don't clear the saved signature if the signature was only cleared for this request (#182).
+            if (this.state.request.signature.value) this.savedIdData.storeSignature(this.state.request.signature);
         }
 
         this.state.request.store();


### PR DESCRIPTION
This also fixes quite a severe bug with the `SignatureInput` (see commit message).

I haven't implemented any tests in this PR as I'm not even sure if that's possible with Cypress.