### PR TITLE
Fix overflowing links not breaking in Chrome

### DIFF
--- a/assets/styles/framework.scss
+++ b/assets/styles/framework.scss
@@ -196,6 +196,8 @@ a:focus {
 }
 
 main a {
+    overflow-wrap: anywhere;
+
     &:not(.button):not(.no-link-decoration):not(.icon) {
         position: relative;
         text-decoration: none;


### PR DESCRIPTION
In the course of our ongoing mission to appease Google, I have noticed that they have been complaining about mobile usability issues on the following pages:

* /company/einwohnermeldeamt-bs/
* /blog/ausweispflichten/

The problems actually don't occur in Firefox as we have set `overflow-wrap: break-word;`. But that doesn't seem to work in Chrome, at least for URLs:

![image](https://user-images.githubusercontent.com/4048809/128687654-6a12bfc0-0f18-4d99-a3c3-13c7e4a3ea65.png)

![image](https://user-images.githubusercontent.com/4048809/128687687-97c1fb22-f33d-47ad-b8e9-9d90dba7e4e9.png)

So, instead we now set `overflow-wrap: anywhere;` for links, which still breaks them nicely in Firefox:

![image](https://user-images.githubusercontent.com/4048809/128687737-5f707824-02f9-46de-bf10-1641909a3198.png)

![image](https://user-images.githubusercontent.com/4048809/128687714-fae94ae4-bfae-4ba4-900c-02f5f3abc82b.png)

And at least breaks them at all in Chrome:

![image](https://user-images.githubusercontent.com/4048809/128687813-e86eda47-b6ad-42ba-b1b8-d4cfb5f65662.png)

![image](https://user-images.githubusercontent.com/4048809/128687822-d7cd5e68-ddc9-4fa5-a78c-8bc9a9826c90.png)
