### PR TITLE
Revert #441 to working solution

### DIFF
--- a/src/Components/SearchBar.js
+++ b/src/Components/SearchBar.js
@@ -140,7 +140,7 @@ if (Privacy.isAllowed(PRIVACY_ACTIONS.SEARCH)) {
             if (typeof this.props.setupPlaceholderChange === 'function') {
                 this.props.setupPlaceholderChange(this.input_element);
             }
-            this.input_element.focus();
+            if (this.props.captureFocus) this.input_element.focus();
         }
 
         componentWillUnmount() {

--- a/src/Components/SearchBar.js
+++ b/src/Components/SearchBar.js
@@ -137,8 +137,10 @@ if (Privacy.isAllowed(PRIVACY_ACTIONS.SEARCH)) {
                 }
             );
             this.algolia_autocomplete.on('autocomplete:selected', this.props.onAutocompleteSelected);
-            if (typeof this.props.setupPlaceholderChange === 'function')
+            if (typeof this.props.setupPlaceholderChange === 'function') {
                 this.props.setupPlaceholderChange(this.input_element);
+            }
+            this.input_element.focus();
         }
 
         componentWillUnmount() {

--- a/src/Components/Wizard.js
+++ b/src/Components/Wizard.js
@@ -138,6 +138,7 @@ export default class Wizard extends Component {
                                 onAutocompleteSelected={(event, suggestion, dataset) => {
                                     this.addCompany(suggestion.document.slug, suggestion.document.name);
                                 }}
+                                captureFocus={true}
                                 debug={true}
                                 placeholder={t('search-company', 'wizard', {
                                     category: t(CATEGORIES[this.state.current_tab], 'categories'),


### PR DESCRIPTION
Since I left #441 lying around for almost a year, I can't critique it appropriately anymore. I took it upon myself to revert to the old way, because it is the only way to capture the focus, since we don't use preact properly (I would love someone to fix that!).
I also made capturing the focus optional, because this might happen unexpectedly in some case, which would be horrible for our users using screen readers.