### PR TITLE
Also cancel redundant deploys on master

### DIFF
--- a/.circleci/cancel-redundant-builds.sh
+++ b/.circleci/cancel-redundant-builds.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Taken from: https://discuss.circleci.com/t/auto-cancel-redundant-builds-on-the-default-branch/39468
+
+# Get the name of the workflow.
+WF_NAME=$(curl --header "Circle-Token: $PERSONAL_CIRCLE_TOKEN" --request GET "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}"|jq -r .name)
+
+# Get the IDs of pipelines on the same branch.
+PIPE_IDS=$(curl --header "Circle-Token: $PERSONAL_CIRCLE_TOKEN" --request GET "https://circleci.com/api/v2/project/gh/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pipeline?branch=$CIRCLE_BRANCH"|jq -r '.items[]|select(.state == "created").id')
+
+# Get the IDs of currently running/on_hold workflows with the same name except the current workflow ID.
+if [ ! -z "$PIPE_IDS" ]; then
+  for PIPE_ID in $PIPE_IDS
+  do
+    curl --header "Circle-Token: $PERSONAL_CIRCLE_TOKEN" --request GET "https://circleci.com/api/v2/pipeline/${PIPE_ID}/workflow"|jq -r --arg CIRCLE_WORKFLOW_ID "$CIRCLE_WORKFLOW_ID" --arg WF_NAME "${WF_NAME}" '.items[]|select(.status == "on_hold" or .status == "running")|select(.name == $WF_NAME)|select(.id != $CIRCLE_WORKFLOW_ID)|.id' >> WF_to_cancel.txt
+  done
+fi
+
+# Cancel any currently running/on_hold workflow with the same name.
+if [ -s WF_to_cancel.txt ]; then
+  echo "Cancelling the following workflow(s):"
+  cat WF_to_cancel.txt
+  while read WF_ID;
+    do
+      curl --header "Circle-Token: $PERSONAL_CIRCLE_TOKEN" --request POST https://circleci.com/api/v2/workflow/$WF_ID/cancel
+    done < WF_to_cancel.txt
+  # Allow some time to complete the cancellation.
+  sleep 2
+else
+    echo "Nothing to cancel"
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,16 @@ executors:
       - image: node:13.14-alpine
 
 jobs:
+  # Circle's "Auto-cancel redundant builds" feature doesn't work on the default branch. When merging PRs on data, this
+  # can cause lots of unnecessary builds. Thus, we emulate this feature here for master.
+  cancel_redundant_builds:
+    executor: docker_hugo_node
+    steps:
+      - checkout
+      - run:
+          command: |
+            ./.circleci/cancel-redundant-builds.sh
+
   build:
     executor: docker_hugo_node
     environment:
@@ -101,6 +111,13 @@ workflows:
   version: 2
   build_test_deploy:
     jobs:
+      - cancel_redundant_builds:
+          # On the other branches, we are using Circle's "Auto-cancel redundant builds" feature, which doesn't require
+          # an access token and is probably a lot more robust.
+          filters:
+              branches:
+                only:
+                  - master
       - build
       - test:
           requires:


### PR DESCRIPTION
Circle's "Auto-cancel redundant builds" feature doesn't work on the default branch. When merging PRs on `data`, this can cause lots of unnecessary builds. With this PR, we now emulate this feature for master, as explained in: <https://discuss.circleci.com/t/auto-cancel-redundant-builds-on-the-default-branch/39468>.

I have already setup the `PERSONAL_CIRCLE_TOKEN` env var.