### PR TITLE
Add `firstPRMergeComment`

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -4,3 +4,6 @@ newPRWelcomeComment: |
   We are glad about every contribution!
 
   Feel free to add yourself to our [`AUTHORS` file](https://github.com/datenanfragen/website/blob/master/AUTHORS) to [appear as a contributor](https://www.datarequests.org/open-source/#contributors) on our websites.
+
+firstPRMergeComment: |
+  Congrats on your first merge! The resulting deploy will take about twenty minutes to go live.


### PR DESCRIPTION
On website, I could actually imagine this being quite useful to inform the user that deploys take around 20 minutes.

_Originally posted by @baltpeter in https://github.com/datenanfragen/data/pull/1229#r696116073_