### PR TITLE
higher image quality, tweak webp hint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ jobs:
   build:
     executor: docker_hugo_node
     environment:
-        - HUGO_VERSION: '0.85.0'
-        - HUGO_BINARY: hugo_extended_0.85.0_linux-64bit
+        - HUGO_VERSION: '0.88.1'
+        - HUGO_BINARY: hugo_extended_0.88.1_linux-64bit
     steps:
       - run:
           command: |
@@ -57,8 +57,8 @@ jobs:
       docker:
         - image: cypress/base:13.8.0
       environment:
-        - HUGO_VERSION: '0.85.0'
-        - HUGO_BINARY: hugo_extended_0.85.0_linux-64bit
+        - HUGO_VERSION: '0.88.1'
+        - HUGO_BINARY: hugo_extended_0.88.1_linux-64bit
       steps:
         - run:
             command: |

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -15,5 +15,4 @@ timeout = "500s"
       unsafe = true
 
 [imaging]
-quality = 80
 hint = "picture"

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -13,3 +13,7 @@ timeout = "500s"
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true
+
+[imaging]
+quality = 80
+hint = "picture"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,13 +3,13 @@ publish = "public"
 command = "./deploy.sh"
 
 [context.production.environment]
-HUGO_VERSION = "0.85.0"
+HUGO_VERSION = "0.88.1"
 YARN_VERSION = "1.22.4"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.85.0"
+HUGO_VERSION = "0.88.1"
 YARN_VERSION = "1.22.4"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.85.0"
+HUGO_VERSION = "0.88.1"
 YARN_VERSION = "1.22.4"


### PR DESCRIPTION
- the tweaked hint gets rid of the weird lines in, e.g. [this image](https://www.datenanfragen.de/blog/jahresbericht-2020/jahresbericht-2020_hu089e1766bccfbf267935c78330f990a2_40902_230x0_resize_q75_h2_box_2.webp)
	- **UPDATE**: seems like that didn't do the trick 	
- the higher quality (default is 75) gets rid of some compression artifacts, but comes with a slight size increase 
  - 15% or 0.77 KB for my [test thumbnail](https://www.datenanfragen.de/blog/datenloeschung-bei-werbetreibenden/datenloeschung-werbetreibende_hu9826f4f2c44a3b0acf4413123c531f73_198477_230x0_resize_q75_h2_box.webp) in my local build
  - 22% or 5.94KB for the [same image in big](https://www.datenanfragen.de/blog/datenloeschung-bei-werbetreibenden/datenloeschung-werbetreibende_hu9826f4f2c44a3b0acf4413123c531f73_198477_784x0_resize_q75_h2_box.webp)