### PR TITLE
Testing: Error Handler 

### DIFF
--- a/cypress/integration/error-handler/console-logging.spec.js
+++ b/cypress/integration/error-handler/console-logging.spec.js
@@ -1,19 +1,33 @@
 describe('Errors should be logged to the console', () => {
     it('Error is shown in console', () => {
+        cy.on('uncaught:exception', (err, runnable) => {
+            return false;
+        });
+
         cy.visit('/');
 
-        // This is not great and we might have to get rid of this test in the future.
-        // The problem is that we can't read console logs in Cypress. As a (bad) workaround, we overload the
-        // `console.log()` function and check that the error has been printed.
-        cy.window().then(win => {
-            win.console.log = function(m) {
-                expect(m).to.include('An unexpected error occurred:');
-            };
-        });
+        // throw custom error to show Error Modal
+        cy.window().then((win) => win.throwError());
 
         // I feel like this might need some explaining. Our error handler does not fire for errors caused by code executed in certain ways, like code entered into the console, for example. The same appears to be the case for code executed through webdriver's driver.executeScript(). Now, for some reason, it does however fire for code executed using the `javascript:` 'protocol'. The problem then is that `driver.get(url)` does not support that protocol. Someone however kindly decided that `document.location = 'javascript:somecode'` should indeed execute said code, which seems incredibly odd and wrong to me but I'll gladly take it, of course.
-        cy.document().then(doc => {
-            doc.location = 'javascript:(function(){throw new Error("Browsers are awesome!")})();';
+        cy.document().then((doc) => {
+            doc.location = 'javascript:(function(){throw new Error()})();';
         });
+
+        cy.get('#error-modal').contains(
+            'Unfortunately, an unexpected error just occurred. We would really appreciate if you took the time to send us an error report via GitHub or email, so we can diagnose the problem. Huge thanks in advance!'
+        );
+        cy.get('#error-modal').contains(
+            'For details on how what data error reports contain and how we process said data, please refer to our '
+        );
+
+        cy.get('#error-modal-github-link')
+            .contains('Report on GitHub')
+            .should('have.attr', 'href')
+            .and('include', 'https://github.com/datenanfragen/website/issues/new');
+        cy.get('#error-modal-email-link')
+            .contains('Report via email')
+            .should('have.attr', 'href')
+            .and('include', 'mailto:dev@datenanfragen.de');
     });
 });

--- a/cypress/integration/error-handler/console-logging.spec.js
+++ b/cypress/integration/error-handler/console-logging.spec.js
@@ -24,10 +24,11 @@ describe('Errors should be logged to the console', () => {
         cy.get('#error-modal-github-link')
             .contains('Report on GitHub')
             .should('have.attr', 'href')
-            .and('include', 'https://github.com/datenanfragen/website/issues/new');
+            .should('match', new RegExp(`^https://github.com/datenanfragen/website/issues/new.*$`));
+
         cy.get('#error-modal-email-link')
             .contains('Report via email')
             .should('have.attr', 'href')
-            .and('include', 'mailto:dev@datenanfragen.de');
+            .should('match', new RegExp(`^mailto:dev@datenanfragen.de.*$`));
     });
 });

--- a/src/test-interface.js
+++ b/src/test-interface.js
@@ -2,6 +2,7 @@
 
 import FlashMessage, { flash } from 'Components/FlashMessage';
 import localforage from 'localforage';
+import { CriticalException } from './Utility/errors';
 
 window.showFlash = function (type, text, duration) {
     flash(
@@ -20,4 +21,8 @@ window.accessLocalForageStore = function (store_name) {
             })
         );
     });
+};
+
+window.throwError = function () {
+    return new CriticalException();
 };


### PR DESCRIPTION
Fixes: #641 

- [x] Is the modal shown correctly?
- [x] Do the mailto: and GitHub links work correctly?
- [ ] Does the "De-JSON-ification" work? 
 
Following the new comments on the issue, I was able to throw the custom error with error code specified. But it never happens if I remove the line below: 

```javascript
doc.location = 'javascript:(function(){throw new Error()})();';
```

Subsequently, the error from the above function is shown on the logs and the same is sent for De-JSON-ification.