### PR TITLE
Add Outlook Webmail Mailto-Link

### DIFF
--- a/src/Components/MailtoDropdown.js
+++ b/src/Components/MailtoDropdown.js
@@ -21,13 +21,11 @@ export const MAILTO_HANDLERS = {
         link: (d) => `https://mail.google.com/mail/?view=cm&fs=1&to=${d.email}&su=${d.subject}&body=${d.body}`,
         countries: ['all'],
     },
-    // TODO: Outlook doesn't work. I think our body may be too long. :(
-    // Reference: https://blogs.msdn.microsoft.com/carloshm/2016/01/16/how-to-compose-a-new-message-or-event-and-populate-fields-in-office365/
-    // outlook: {
-    //     link: d =>
-    //         `https://outlook.live.com/owa/?path=/mail/action/compose&to=${d.email}&subject=${d.subject}&body=${d.body}`,
-    //     countries: ['all']
-    // },
+    outlook: {
+        link: (d) =>
+            `https://outlook.live.com/mail/0/deeplink/compose?to=${d.email}&subject=${d.subject}&body=${d.body}`,
+        countries: ['all'],
+    },
     yahoo: {
         link: (d) => `https://compose.mail.yahoo.com/?to=${d.email}&subject=${d.subject}&body=${d.body}`,
         countries: ['all'],


### PR DESCRIPTION
see also: #402 
source for URL scheme: [https://stackoverflow.com/a/69080263](https://stackoverflow.com/a/69080263)

I tested it with a few generated letters and it seems to work fine. Additional and more structured testing would probably be a good idea.
Translations for "outlook" are still there.