### PR TITLE
Actually hide the dropdown when the button is disabled

### DIFF
--- a/src/Components/MailtoDropdown.js
+++ b/src/Components/MailtoDropdown.js
@@ -148,7 +148,7 @@ export default class MailtoDropdown extends Component {
                         &nbsp;&nbsp;
                         <span className={'icon ' + (props.done ? 'icon-paper-plane' : 'icon-email')} />
                     </button>
-                    {props.letter ? (
+                    {props.enabled ? (
                         <div className="dropdown" style="padding: 15px; width: 270px; max-width: 90vw;">
                             <Text id="mailto-dropdown-explanation" />
 


### PR DESCRIPTION
This is an attempt to \*again\* fix the broken production tests. Since I can not reproduce the error behavior locally, I can only guess at what is going wrong. Without the recordings I can also not really determine whether the tests are wrong or our code is not working.