### PR TITLE
Declare email field in trackingFields as 'email'

### DIFF
--- a/src/Utility/requests.js
+++ b/src/Utility/requests.js
@@ -50,7 +50,7 @@ export function trackingFields(locale = LOCALE) {
         },
         {
             desc: t_r('email', locale),
-            type: 'input',
+            type: 'email',
             optional: false,
             value: '',
         },


### PR DESCRIPTION
This otherwise makes sending many tracking requests very
annoying. Guess how I know. :D 