### PR TITLE
Fixed comment rating styling on mobile

### DIFF
--- a/assets/styles/elements.scss
+++ b/assets/styles/elements.scss
@@ -200,18 +200,23 @@ input:disabled {
     padding: 10px;
 }
 
-.comment {
+.star {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin-top: 5px;
     @include mobile {
-        div {
-            left: 10px;
-            top: inherit !important;
-            margin-top: 0 !important;
-        }
-        p {
-            margin-top: 6vh;
+        left: 10px;
+        top: inherit !important;
+        margin-top: 0 !important;
+    }
+    & + p {
+        @include mobile {
+            margin-top: 40px;
         }
     }
 }
+
 .select-container {
     position: relative;
     width: 200px;

--- a/src/Components/CommentsWidget.js
+++ b/src/Components/CommentsWidget.js
@@ -143,7 +143,7 @@ export class Comment extends Component {
                     <strong>{this.props.author}</strong> ({new Date(this.props.date).toLocaleString()})
                 </span>
                 {this.props.additional.rating ? (
-                    <div style="position: absolute; top: 0; right: 0; margin-top: 5px;">
+                    <div className="star">
                         <StarWidget
                             id={'stars-' + this.props.id}
                             initial={this.props.additional.rating}


### PR DESCRIPTION
Fix for the issue: #448 

Results:
![image](https://user-images.githubusercontent.com/67395591/136954647-6d96c4fd-475f-40c8-bf97-aebfe3c5b1a8.png)
