### PR TITLE
Fix reversed condition in scheduled production test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
             command: |
               yarn
               yarn cypress verify
-              if [ -z ${CYPRESS_RECORD_KEY+x} ]; then yarn cypress run --record; else yarn cypress run; fi
+              if [ -z ${CYPRESS_RECORD_KEY+x} ]; then yarn cypress run; else yarn cypress run --record; fi
 
 workflows:
   version: 2


### PR DESCRIPTION
We want to record the run if `CYPRESS_RECORD_KEY` is set not if it
isn't…