### PR TITLE
Hide fixed fields with same value/desc

### DIFF
--- a/src/Components/Generator/DynamicInputContainer.js
+++ b/src/Components/Generator/DynamicInputContainer.js
@@ -44,33 +44,45 @@ export default class DynamicInputContainer extends Component {
         // As this is at least the second time I have struggled to remember this: This is the button next to the 'add
         // new field' menu which allows you to add fields you have defined in the 'My saved data' section.
         let fill_fields = [];
+
         if (this.props.fillFields)
             this.props.fillFields.forEach((field) => {
-                fill_fields.push(
-                    <div className="fill-field">
-                        <div style="display: table-cell">
-                            {field.desc}:{' '}
-                            <span className="fill-field-value">
-                                {field.type === 'address'
-                                    ? field.value['street_1']
-                                        ? field.value['street_1'] + ' …'
-                                        : ''
-                                    : field.value}
-                            </span>
+                let isFieldPresent = false;
+
+                for (let addedField of this.props.fields) {
+                    if (field.type === addedField.type && field.desc === addedField.desc) {
+                        isFieldPresent = true;
+                        break;
+                    }
+                }
+
+                if (!isFieldPresent)
+                    fill_fields.push(
+                        <div className="fill-field">
+                            <div style="display: table-cell">
+                                {field.desc}:{' '}
+                                <span className="fill-field-value">
+                                    {field.type === 'address'
+                                        ? field.value['street_1']
+                                            ? field.value['street_1'] + ' …'
+                                            : ''
+                                        : field.value}
+                                </span>
+                            </div>
+                            <div style="display: table-cell; width: 60px;">
+                                <button
+                                    style="float: none;"
+                                    className="button button-small button-primary icon-arrow-right"
+                                    onClick={() => {
+                                        this.addFillField(field);
+                                    }}
+                                    title={t('add-input', 'generator')}
+                                />
+                            </div>
                         </div>
-                        <div style="display: table-cell; width: 60px;">
-                            <button
-                                style="float: none;"
-                                className="button button-small button-primary icon-arrow-right"
-                                onClick={() => {
-                                    this.addFillField(field);
-                                }}
-                                title={t('add-input', 'generator')}
-                            />
-                        </div>
-                    </div>
-                );
+                    );
             });
+
         return (
             <IntlProvider scope="generator" definition={I18N_DEFINITION}>
                 <div className="dynamic-input-container">

--- a/src/Components/Generator/DynamicInputContainer.js
+++ b/src/Components/Generator/DynamicInputContainer.js
@@ -43,21 +43,13 @@ export default class DynamicInputContainer extends Component {
         }
         // As this is at least the second time I have struggled to remember this: This is the button next to the 'add
         // new field' menu which allows you to add fields you have defined in the 'My saved data' section.
-        let fill_fields = [];
+        let fill_fields = this.props.fillFields
+            ?.map((field) => {
+                let condition = (addedField) => field.type === addedField.type && field.desc === addedField.desc,
+                    isFieldPresent = this.props.fields.some(condition);
 
-        if (this.props.fillFields)
-            this.props.fillFields.forEach((field) => {
-                let isFieldPresent = false;
-
-                for (let addedField of this.props.fields) {
-                    if (field.type === addedField.type && field.desc === addedField.desc) {
-                        isFieldPresent = true;
-                        break;
-                    }
-                }
-
-                if (!isFieldPresent)
-                    fill_fields.push(
+                if (!isFieldPresent) {
+                    return (
                         <div className="fill-field">
                             <div style="display: table-cell">
                                 {field.desc}:{' '}
@@ -81,7 +73,11 @@ export default class DynamicInputContainer extends Component {
                             </div>
                         </div>
                     );
-            });
+                }
+
+                return null;
+            })
+            .filter((elem) => elem !== null);
 
         return (
             <IntlProvider scope="generator" definition={I18N_DEFINITION}>

--- a/src/Components/Generator/DynamicInputContainer.js
+++ b/src/Components/Generator/DynamicInputContainer.js
@@ -48,7 +48,7 @@ export default class DynamicInputContainer extends Component {
                 let condition = (addedField) => field.type === addedField.type && field.desc === addedField.desc,
                     isFieldPresent = this.props.fields.some(condition);
 
-                if (!isFieldPresent) {
+                if (!isFieldPresent && !!field.value) {
                     return (
                         <div className="fill-field">
                             <div style="display: table-cell">


### PR DESCRIPTION
https://user-images.githubusercontent.com/52719271/137610475-b2da2570-65b4-4d94-bbdd-97e7cac12b34.mp4

Closes #735 

Currently it only checks if the field descriptions and types are equal or not. In case of addresses, there's an object that I could check if they are equal or not but then it doesn't make sense because I don't think people can store addresses with the same description on the [My Saved Data](https://www.datarequests.org/id-data-controls/) page.

@baltpeter @zner0L 