### PR TITLE
Suggest: Don't drop tokens for similar companies search

### DIFF
--- a/src/suggest-edit.js
+++ b/src/suggest-edit.js
@@ -170,6 +170,7 @@ function suggestSimilarNamedCompanies() {
                 sort_by: '_text_match:desc,sort-index:asc',
                 num_typos: 1,
                 per_page: 5,
+                drop_tokens_threshold: 0,
             };
 
             const nameInput = nameCell.querySelector('input');


### PR DESCRIPTION
Immediately after merging #787, I of course noticed one more problem.
With the current implementation, you get a ton of irrelevant results
as Typesense will drop tokens until it finds a match. So, if you enter
"Some Company Inc.", which doesn't exist, you still get five 'similar'
companies as they all have the "Inc." suffix.

That obviously isn't a good user experience. With this PR, we tell
Typesense to not drop tokens anymore. From my testing, this seems to
still produce the same relevant results as before but much fewer
irrelevant results.