### PR TITLE
Improve Hugo build speed by optimizing related company computation

### DIFF
--- a/layouts/partials/related-companies.html
+++ b/layouts/partials/related-companies.html
@@ -9,8 +9,8 @@
 
     {{ range (where .Site.Pages "Section" "company") }}
         {{ $num_common_categories := intersect $.Params.categories .Params.categories | len }}
-        {{ $num_common_countries := intersect ($.Param "relevant-countries") (.Param "relevant-countries") | len }}
         {{ if and (gt $num_common_categories 0) (ne .Permalink $.Permalink) (not .Params.nsfw) }}
+            {{ $num_common_countries := intersect ($.Param "relevant-countries") (.Param "relevant-countries") | len }}
             {{ $score := add (div (float $num_common_categories) $num_categories) (div $num_common_countries $num_countries) }}
 
             {{ if (or (lt ($related_pages | len) 5) (gt $score $lowest_score)) }}

--- a/layouts/partials/related-companies.html
+++ b/layouts/partials/related-companies.html
@@ -5,12 +5,21 @@
     {{ $num_categories := (cond (isset .Params "categories") .Params.categories slice) | len }}
     {{ $num_countries := (.Param "relevant-countries") | len }}
 
+    {{ $lowest_score := 999999 }}
+
     {{ range (where .Site.Pages "Section" "company") }}
         {{ $num_common_categories := intersect $.Params.categories .Params.categories | len }}
         {{ $num_common_countries := intersect ($.Param "relevant-countries") (.Param "relevant-countries") | len }}
         {{ if and (gt $num_common_categories 0) (ne .Permalink $.Permalink) (not .Params.nsfw) }}
             {{ $score := add (div (float $num_common_categories) $num_categories) (div $num_common_countries $num_countries) }}
-            {{ $related_pages = $related_pages | append (dict "page" . "score" $score) }}
+
+            {{ if (or (lt ($related_pages | len) 5) (gt $score $lowest_score)) }}
+                {{ $related_pages = $related_pages | append (dict "page" . "score" $score) }}
+
+                {{ if lt $score $lowest_score }}
+                    {{ $lowest_score = $score }}
+                {{ end }}
+            {{ end }}
         {{ end }}
     {{ end }}
     {{ $related_pages = sort $related_pages "score" "desc" }}

--- a/layouts/partials/related-companies.html
+++ b/layouts/partials/related-companies.html
@@ -8,16 +8,18 @@
     {{ $lowest_score := 999999 }}
 
     {{ range (where .Site.Pages "Section" "company") }}
-        {{ $num_common_categories := intersect $.Params.categories .Params.categories | len }}
-        {{ if and (gt $num_common_categories 0) (ne .Permalink $.Permalink) (not .Params.nsfw) }}
-            {{ $num_common_countries := intersect ($.Param "relevant-countries") (.Param "relevant-countries") | len }}
-            {{ $score := add (div (float $num_common_categories) $num_categories) (div $num_common_countries $num_countries) }}
+        {{ if and (ne .Permalink $.Permalink) (not .Params.nsfw) }}
+            {{ $num_common_categories := intersect $.Params.categories .Params.categories | len }}
+            {{ if (gt $num_common_categories 0) }}
+                {{ $num_common_countries := intersect ($.Param "relevant-countries") (.Param "relevant-countries") | len }}
+                {{ $score := add (div (float $num_common_categories) $num_categories) (div $num_common_countries $num_countries) }}
 
-            {{ if (or (lt ($related_pages | len) 5) (gt $score $lowest_score)) }}
-                {{ $related_pages = $related_pages | append (dict "page" . "score" $score) }}
+                {{ if (or (lt ($related_pages | len) 5) (gt $score $lowest_score)) }}
+                    {{ $related_pages = $related_pages | append (dict "page" . "score" $score) }}
 
-                {{ if lt $score $lowest_score }}
-                    {{ $lowest_score = $score }}
+                    {{ if lt $score $lowest_score }}
+                        {{ $lowest_score = $score }}
+                    {{ end }}
                 {{ end }}
             {{ end }}
         {{ end }}

--- a/layouts/partials/related-companies.html
+++ b/layouts/partials/related-companies.html
@@ -7,19 +7,17 @@
 
     {{ $lowest_score := 999999 }}
 
-    {{ range (where .Site.Pages "Section" "company") }}
+    {{ range (where (where .Site.Pages "Section" "company") "Params.categories" "intersect" .Params.categories) }}
         {{ if and (ne .Permalink $.Permalink) (not .Params.nsfw) }}
             {{ $num_common_categories := intersect $.Params.categories .Params.categories | len }}
-            {{ if (gt $num_common_categories 0) }}
-                {{ $num_common_countries := intersect ($.Param "relevant-countries") (.Param "relevant-countries") | len }}
-                {{ $score := add (div (float $num_common_categories) $num_categories) (div $num_common_countries $num_countries) }}
+            {{ $num_common_countries := intersect ($.Param "relevant-countries") (.Param "relevant-countries") | len }}
+            {{ $score := add (div (float $num_common_categories) $num_categories) (div $num_common_countries $num_countries) }}
 
-                {{ if (or (lt ($related_pages | len) 5) (gt $score $lowest_score)) }}
-                    {{ $related_pages = $related_pages | append (dict "page" . "score" $score) }}
+            {{ if (or (lt ($related_pages | len) 5) (gt $score $lowest_score)) }}
+                {{ $related_pages = $related_pages | append (dict "page" . "score" $score) }}
 
-                    {{ if lt $score $lowest_score }}
-                        {{ $lowest_score = $score }}
-                    {{ end }}
+                {{ if lt $score $lowest_score }}
+                    {{ $lowest_score = $score }}
                 {{ end }}
             {{ end }}
         {{ end }}


### PR DESCRIPTION
I felt like doing a bit of optimization for our Hugo build and the obvious place for that is the related companies template.

Through a series of relatively simple changes, I was able to get the build time from 27.7s down to 16.4s on my machine.