### PR TITLE
Fix bugs introduced by #835 (closes #836)

### DIFF
--- a/assets/styles/elements.scss
+++ b/assets/styles/elements.scss
@@ -370,6 +370,11 @@ input[type='search'].aa-input-search {
 
     h4 {
         margin: 0;
+
+        .icon {
+            position: relative;
+            z-index: 1;
+        }
     }
 
     a {

--- a/src/Components/SearchBar.js
+++ b/src/Components/SearchBar.js
@@ -80,7 +80,7 @@ if (Privacy.isAllowed(PRIVACY_ACTIONS.SEARCH)) {
                                     (this.props.anchorize
                                         ? `<a class="no-link-decoration" href="${BASE_URL}company/${d.slug}">`
                                         : '') +
-                                    '<div class="anchor-overlay" aria-hidden="true"></div><span><h4>' +
+                                    '<div class="anchor-overlay" aria-hidden="true"></div><h4>' +
                                     (name_hs.length === 1 ? name_hs[0].snippet : d.name) +
                                     (d.quality === 'tested'
                                         ? '&nbsp;<span class="icon icon-check-badge color-green-800" title="' +
@@ -91,13 +91,13 @@ if (Privacy.isAllowed(PRIVACY_ACTIONS.SEARCH)) {
                                           t('quality-unverified', 'search') +
                                           '"></span>'
                                         : '') +
-                                    '</h4></span>' +
+                                    '</h4>' +
                                     (this.props.anchorize ? '</a>' : '') +
                                     (d.runs?.length
                                         ? '<span>' +
                                           t('also-runs', 'search') +
                                           (runs_hs.length === 1 ? runs_hs[0].snippets : d.runs).join(', ') +
-                                          '</span>'
+                                          '</span><br>'
                                         : '') +
                                     (d.categories?.length
                                         ? '<span>' +


### PR DESCRIPTION
- If a company had both runs entries and categories, the categories were not on a separate line:
  
  ![image](https://user-images.githubusercontent.com/4048809/147359155-58a3fe05-af31-4e1c-9d8c-5ad8a49186e8.png)
- The icon hover text didn't work anymore due to the overlay (#836).
- I see no reason to wrap the h4 in an otherwise empty span.