### PR TITLE
add skip-to-content link, fixes #838

### DIFF
--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -112,7 +112,7 @@ a #logo {
 
 #skip-to-content {
     padding: 50px;
-    color: black;
+    color: $bg-color;
     background-color: $primary-color;
     position: absolute;
     transform: translateY(-200%);

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -117,7 +117,7 @@ a #logo {
     position: absolute;
     transform: translateY(-200%);
     transition: transform 0.2s;
-    @media (prefers-reduced-motion: reduce) {
+    @media screen and (prefers-reduced-motion: reduce) {
         transition: transform 0s;
     }
     &:focus {

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -113,7 +113,7 @@ a #logo {
 #skip-to-content {
     padding: 50px;
     color: black;
-    background-color: color('red', 500);
+    background-color: $primary-color;
     position: absolute;
     transform: translateY(-200%);
     transition: transform 0.2s;

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -118,7 +118,7 @@ a #logo {
     transform: translateY(-200%);
     transition: transform 0.2s;
     @media screen and (prefers-reduced-motion: reduce) {
-        transition: transform 0s;
+        transition: none;
     }
     &:focus {
         transform: translateY(0%);

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -110,6 +110,21 @@ a #logo {
     }
 }
 
+#skip-to-content {
+    padding: 50px;
+    color: black;
+    background-color: color('red', 500);
+    position: absolute;
+    transform: translateY(-200%);
+    transition: transform 0.2s;
+    @media (prefers-reduced-motion: reduce) {
+        transition: transform 0s;
+    }
+    &:focus {
+        transform: translateY(0%);
+    }
+}
+
 /* Home */
 #home-hero-bg {
     height: 95vh;

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -44,11 +44,7 @@
 </head>
 
 <body>
-    {{ if .IsHome }}
-        <a id="skip-to-content" href="#heading">{{T "skip-to-content"}}</a>
-    {{ else }}
-        <a id="skip-to-content" href="#home-hero">{{T "skip-to-content"}}</a>
-    {{ end }}
+    <a id="skip-to-content" href="{{ if .IsHome }}#home-hero{{ else }}#heading{{ end }}">{{T "skip-to-content"}}</a>
     <aside id="flash-messages"></aside>
     <header id="nav-header">
         <div id="nav-header-bg"></div>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -44,7 +44,11 @@
 </head>
 
 <body>
-    <a id="skip-to-content" href="#heading">{{T "skip-to-content"}}</a>
+    {{ if .IsHome }}
+        <a id="skip-to-content" href="#heading">{{T "skip-to-content"}}</a>
+    {{ else }}
+        <a id="skip-to-content" href="#home-hero">{{T "skip-to-content"}}</a>
+    {{ end }}
     <aside id="flash-messages"></aside>
     <header id="nav-header">
         <div id="nav-header-bg"></div>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -44,6 +44,7 @@
 </head>
 
 <body>
+    <a id="skip-to-content" href="#heading">{{T "skip-to-content"}}</a>
     <aside id="flash-messages"></aside>
     <header id="nav-header">
         <div id="nav-header-bg"></div>

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -36,6 +36,7 @@
         "header-privacy-controls": "Datenschutzeinstellungen",
         "header-id-data-controls": "Meine gespeicherten Daten",
         "header-open-menu": "Menü öffnen",
+        "skip-to-content": "Zum Inhalt springen",
         "footer-about-us": "Wir sind der Datenanfragen.de e.&nbsp;V., ein gemeinnütziger Verein, der es sich zur Aufgabe gemacht hat, Dir bei der Ausübung Deines Rechts auf Datenschutz zu helfen.",
         "footer-learn-more": "Erfahre mehr.",
         "home-hero-line-1": "Du hast ein Recht auf",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -36,6 +36,7 @@
         "header-privacy-controls": "Privacy controls",
         "header-id-data-controls": "My saved data",
         "header-open-menu": "Open menu",
+        "skip-to-content": "Skip to content",
         "footer-about-us": "We are Datenanfragen.de e.&nbsp;V., a registered non-profit from Germany. We have made it our mission to help you exercise your right to privacy.",
         "footer-learn-more": "Learn more.",
         "home-hero-line-1": "You have a right to",


### PR DESCRIPTION
I had to skip `stylelint`:

 > 113:4  ✖  Expected #skip-to-content is used with @media (prefers-reduced-motion)  a11y/media-prefers-reduced-motion
 
 Not sure why that triggers o.o