### PR TITLE
Change "Amazon Deutschland" -> "Amazon Europe" in wizard use case test

### DIFF
--- a/cypress/integration/use-cases/wizard.spec.js
+++ b/cypress/integration/use-cases/wizard.spec.js
@@ -24,7 +24,7 @@ describe('Using the wizard', () => {
         cy.get('#wizard-buttons > .button-primary').click();
 
         // Commerce
-        cy.addCompanyToWizard('amazon', 'Amazon Deutschland');
+        cy.addCompanyToWizard('amazon', 'Amazon Europe');
         cy.addCompanyToWizard('ebay', 'eBay GmbH');
         cy.addCompanyToWizard('h&m', 'H&M Hennes');
 


### PR DESCRIPTION
The order the runs elements are shown in was probably changed by the
Typesense update. Not sure why we were matching on a runs entry here,
anyway…