### PR TITLE
Prettier: Use prettier-plugin-organize-imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
         "postcss-preset-env": "^7.0.1",
         "postcss-url": "^10.1.3",
         "prettier": "^2.5.0",
+        "prettier-plugin-organize-imports": "^2.3.4",
         "speed-measure-webpack-plugin": "^1.5.0",
         "stylelint": "^14.1.0",
         "stylelint-a11y": "^1.2.1",

--- a/src/Components/ActWidget.tsx
+++ b/src/Components/ActWidget.tsx
@@ -1,12 +1,12 @@
 import { render } from 'preact';
-import { RequestGeneratorBuilder } from './RequestGeneratorBuilder';
-import type { RequestType, TransportMedium } from '../types/request';
-import type { Company } from '../types/company';
-import { ActionButton } from './Generator/ActionButton';
-import { StatefulSignatureInput } from './Generator/SignatureInput';
-import { RequestTypeChooser } from './Generator/RequestTypeChooser';
-import { StatefulDynamicInputContainer } from './Generator/DynamicInputContainer';
 import { createGeneratorStore, RequestGeneratorProvider, useGeneratorStore } from '../store/generator';
+import type { Company } from '../types/company';
+import type { RequestType, TransportMedium } from '../types/request';
+import { ActionButton } from './Generator/ActionButton';
+import { StatefulDynamicInputContainer } from './Generator/DynamicInputContainer';
+import { RequestTypeChooser } from './Generator/RequestTypeChooser';
+import { StatefulSignatureInput } from './Generator/SignatureInput';
+import { RequestGeneratorBuilder } from './RequestGeneratorBuilder';
 
 type ActWidgetProps = {
     requestTypes: RequestType[];

--- a/src/Components/CommentsWidget.tsx
+++ b/src/Components/CommentsWidget.tsx
@@ -1,10 +1,10 @@
 import { Fragment, JSX } from 'preact';
-import { useState, useEffect, useCallback } from 'preact/hooks';
-import { IntlProvider, Text, MarkupText } from 'preact-i18n';
-import { FlashMessage, flash } from '../Components/FlashMessage';
-import { StarWidget } from './StarWidget';
-import t from '../Utility/i18n';
+import { IntlProvider, MarkupText, Text } from 'preact-i18n';
+import { useCallback, useEffect, useState } from 'preact/hooks';
+import { flash, FlashMessage } from '../Components/FlashMessage';
 import { rethrow, WarningException } from '../Utility/errors';
+import t from '../Utility/i18n';
+import { StarWidget } from './StarWidget';
 
 const api_url = 'https://backend.datenanfragen.de/comments';
 const target = `${window.LOCALE}/${document.location.pathname.replace(/^\s*\/*\s*|\s*\/*\s*$/gm, '')}`;

--- a/src/Components/DeprecatedModal.js
+++ b/src/Components/DeprecatedModal.js
@@ -1,7 +1,7 @@
-import { render, Component } from 'preact';
+import { Component, render } from 'preact';
 import { createPortal } from 'preact/compat';
-import t from '../Utility/i18n';
 import PropTypes from 'prop-types';
+import t from '../Utility/i18n';
 
 // TODO: Get rid of this once we've moved everything to the new modal hook.
 export default class DeprecatedModal extends Component {

--- a/src/Components/DonationWidget.js
+++ b/src/Components/DonationWidget.js
@@ -1,12 +1,12 @@
-import { render, Component } from 'preact';
-import { IntlProvider, Text, MarkupText } from 'preact-i18n';
+import { Component, render } from 'preact';
+import { IntlProvider, MarkupText, Text } from 'preact-i18n';
+import { flash, FlashMessage } from '../Components/FlashMessage';
+import { clientPost } from '../Utility/browser';
 import { almostUniqueId, renderMoney } from '../Utility/common';
 import { CriticalException, rethrow } from '../Utility/errors';
 import t from '../Utility/i18n';
-import { FlashMessage, flash } from '../Components/FlashMessage';
-import { Radio } from './Radio';
-import { clientPost } from '../Utility/browser';
 import { LoadingIndicator } from './LoadingIndicator';
+import { Radio } from './Radio';
 
 const DONATIONS_API = 'https://backend.datenanfragen.de/donation';
 const SUGGESTED_AMOUNTS = [5, 10, 15, 25, 50, 75, 100, 150, 200, 250];

--- a/src/Components/FeatureDisabledWidget.tsx
+++ b/src/Components/FeatureDisabledWidget.tsx
@@ -1,5 +1,5 @@
 import type { ComponentChildren } from 'preact';
-import { MarkupText, IntlProvider } from 'preact-i18n';
+import { IntlProvider, MarkupText } from 'preact-i18n';
 import t from '../Utility/i18n';
 
 type FeatureDisabledWidgetProps = {

--- a/src/Components/FlashMessage.tsx
+++ b/src/Components/FlashMessage.tsx
@@ -1,5 +1,5 @@
-import { render, ComponentChildren, Fragment, VNode } from 'preact';
-import { useState, useEffect, useCallback } from 'preact/hooks';
+import { ComponentChildren, Fragment, render, VNode } from 'preact';
+import { useCallback, useEffect, useState } from 'preact/hooks';
 import t from '../Utility/i18n';
 
 type FlashMessageProps = {

--- a/src/Components/Footnote.tsx
+++ b/src/Components/Footnote.tsx
@@ -1,5 +1,5 @@
 import type { ComponentChildren } from 'preact';
-import { Text, IntlProvider } from 'preact-i18n';
+import { IntlProvider, Text } from 'preact-i18n';
 import { useEffect, useRef } from 'preact/hooks';
 
 type FootnoteProps = {

--- a/src/Components/Generator/ActionButton.tsx
+++ b/src/Components/Generator/ActionButton.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from 'preact';
-import { Text, IntlProvider } from 'preact-i18n';
+import { IntlProvider, Text } from 'preact-i18n';
 import { useGeneratorStore } from '../../store/generator';
 import { MailtoDropdown } from '../MailtoDropdown';
 

--- a/src/Components/Generator/CompanySelector.tsx
+++ b/src/Components/Generator/CompanySelector.tsx
@@ -1,8 +1,8 @@
-import type { Company } from '../../types/company';
 import type { Except } from 'type-fest';
-import t from '../../Utility/i18n';
 import { useGeneratorStore } from '../../store/generator';
-import { SearchBarProps, SearchBar } from '../SearchBar';
+import type { Company } from '../../types/company';
+import t from '../../Utility/i18n';
+import { SearchBar, SearchBarProps } from '../SearchBar';
 import { useNewRequestModal } from './NewRequestButton';
 
 type CompanySelectorProps = { newRequestHook: () => void } & Partial<Except<SearchBarProps, 'anchorize' | 'index'>>;

--- a/src/Components/Generator/CompanyWidget.tsx
+++ b/src/Components/Generator/CompanyWidget.tsx
@@ -1,7 +1,7 @@
-import t from '../../Utility/i18n';
-import { Text, IntlProvider } from 'preact-i18n';
-import { Accordion } from '../Accordion';
+import { IntlProvider, Text } from 'preact-i18n';
 import { useGeneratorStore } from '../../store/generator';
+import t from '../../Utility/i18n';
+import { Accordion } from '../Accordion';
 
 export const CompanyWidget = () => {
     const company = useGeneratorStore((state) => state.current_company);

--- a/src/Components/Generator/CustomRequestInput.tsx
+++ b/src/Components/Generator/CustomRequestInput.tsx
@@ -1,8 +1,8 @@
-import type { CustomTemplateName } from '../../types/request';
-import { MarkupText, Text, IntlProvider } from 'preact-i18n';
-import t from '../../Utility/i18n';
+import { IntlProvider, MarkupText, Text } from 'preact-i18n';
 import { useGeneratorStore } from '../../store/generator';
-import { EMTPY_ADDRESS, CUSTOM_TEMPLATE_OPTIONS } from '../../Utility/requests';
+import type { CustomTemplateName } from '../../types/request';
+import t from '../../Utility/i18n';
+import { CUSTOM_TEMPLATE_OPTIONS, EMTPY_ADDRESS } from '../../Utility/requests';
 import { InputControl } from './DynamicInput';
 
 export const CustomRequestInput = () => {

--- a/src/Components/Generator/DynamicInput.tsx
+++ b/src/Components/Generator/DynamicInput.tsx
@@ -1,9 +1,9 @@
+import { produce } from 'immer';
 import type { JSX } from 'preact';
+import { IntlProvider, Text } from 'preact-i18n';
 import type { Address, AddressIdData, IdDataElement } from '../../types/request';
-import { Text, IntlProvider } from 'preact-i18n';
 import t from '../../Utility/i18n';
 import { ADDRESS_STRING_PROPERTIES } from '../../Utility/requests';
-import { produce } from 'immer';
 
 type DynamicInputProps = {
     id: string;

--- a/src/Components/Generator/DynamicInputContainer.tsx
+++ b/src/Components/Generator/DynamicInputContainer.tsx
@@ -1,11 +1,11 @@
 import type { ComponentChildren } from 'preact';
-import type { IdDataElement } from '../../types/request';
+import { IntlProvider, MarkupText, Text } from 'preact-i18n';
 import { useMemo, useState } from 'preact/hooks';
-import { DynamicInput } from './DynamicInput';
-import { Text, MarkupText, IntlProvider } from 'preact-i18n';
-import t from '../../Utility/i18n';
-import { adressesEqual, isFieldEmpty, EMTPY_ADDRESS } from '../../Utility/requests';
 import { useGeneratorStore } from '../../store/generator';
+import type { IdDataElement } from '../../types/request';
+import t from '../../Utility/i18n';
+import { adressesEqual, EMTPY_ADDRESS, isFieldEmpty } from '../../Utility/requests';
+import { DynamicInput } from './DynamicInput';
 
 type DynamicInputContainerProps = {
     id: string;

--- a/src/Components/Generator/NewRequestButton.tsx
+++ b/src/Components/Generator/NewRequestButton.tsx
@@ -1,13 +1,13 @@
-import { ActionButton } from '../Generator/ActionButton';
+import type { JSX } from 'preact';
 import { IntlProvider, Text } from 'preact-i18n';
+import { useCallback, useState } from 'preact/hooks';
+import { SavedCompanies } from '../../DataType/SavedCompanies';
 import { useGeneratorStore } from '../../store/generator';
 import { clearUrlParameters } from '../../Utility/browser';
-import { useCallback, useState } from 'preact/hooks';
-import { useModal } from '../Modal';
 import t from '../../Utility/i18n';
-import type { JSX } from 'preact';
 import { Privacy, PRIVACY_ACTIONS } from '../../Utility/Privacy';
-import { SavedCompanies } from '../../DataType/SavedCompanies';
+import { ActionButton } from '../Generator/ActionButton';
+import { useModal } from '../Modal';
 
 type NewRequestButtonProps = {
     newRequestHook?: (arg?: unknown) => void;

--- a/src/Components/Generator/RecipientInput.tsx
+++ b/src/Components/Generator/RecipientInput.tsx
@@ -1,6 +1,6 @@
+import { IntlProvider, Text } from 'preact-i18n';
 import type { TransportMedium } from '../../types/request';
 import t from '../../Utility/i18n';
-import { Text, IntlProvider } from 'preact-i18n';
 
 type RecipientInputProps = {
     recipientAddress?: string;

--- a/src/Components/Generator/RequestFlags.tsx
+++ b/src/Components/Generator/RequestFlags.tsx
@@ -1,6 +1,6 @@
-import { useGeneratorStore } from '../../store/generator';
 import { Fragment } from 'preact';
 import { Text } from 'preact-i18n';
+import { useGeneratorStore } from '../../store/generator';
 import t from '../../Utility/i18n';
 
 export function RequestFlags() {

--- a/src/Components/Generator/RequestForm.tsx
+++ b/src/Components/Generator/RequestForm.tsx
@@ -1,15 +1,15 @@
 import { ComponentChildren } from 'preact';
-import { DynamicInputContainer } from './DynamicInputContainer';
-import { SignatureInput } from './SignatureInput';
-import { MarkupText, Text, IntlProvider } from 'preact-i18n';
+import { IntlProvider, MarkupText, Text } from 'preact-i18n';
+import { useGeneratorStore } from '../../store/generator';
 import t from '../../Utility/i18n';
 import { Accordion } from '../Accordion';
-import { RequestTypeChooser } from './RequestTypeChooser';
-import { RecipientInput } from './RecipientInput';
-import { TransportMediumChooser } from './TransportMediumChooser';
-import { useGeneratorStore } from '../../store/generator';
-import { RequestFlags } from './RequestFlags';
 import { CustomRequestInput } from './CustomRequestInput';
+import { DynamicInputContainer } from './DynamicInputContainer';
+import { RecipientInput } from './RecipientInput';
+import { RequestFlags } from './RequestFlags';
+import { RequestTypeChooser } from './RequestTypeChooser';
+import { SignatureInput } from './SignatureInput';
+import { TransportMediumChooser } from './TransportMediumChooser';
 
 type RequestFormProps = {
     children: ComponentChildren;

--- a/src/Components/Generator/RequestTypeChooser.tsx
+++ b/src/Components/Generator/RequestTypeChooser.tsx
@@ -1,8 +1,8 @@
+import { useGeneratorStore } from '../../store/generator';
 import type { RequestType } from '../../types/request';
 import t from '../../Utility/i18n';
-import { Radio } from '../Radio';
 import { REQUEST_TYPES } from '../../Utility/requests';
-import { useGeneratorStore } from '../../store/generator';
+import { Radio } from '../Radio';
 
 type RequestTypeChooserProps = {
     request_types?: RequestType[];

--- a/src/Components/Generator/SignatureInput.tsx
+++ b/src/Components/Generator/SignatureInput.tsx
@@ -1,9 +1,9 @@
 import { JSX } from 'preact';
-import { useRef, Ref, useEffect, MutableRef, useState } from 'preact/hooks';
-import { Text, IntlProvider } from 'preact-i18n';
+import { IntlProvider, Text } from 'preact-i18n';
+import { MutableRef, Ref, useEffect, useRef, useState } from 'preact/hooks';
+import { useGeneratorStore } from '../../store/generator';
 import type { Signature } from '../../types/request';
 import { detectBlockedCanvasImageExtraction } from '../../Utility/browser';
-import { useGeneratorStore } from '../../store/generator';
 
 type Color = string;
 

--- a/src/Components/Generator/TransportMediumChooser.tsx
+++ b/src/Components/Generator/TransportMediumChooser.tsx
@@ -1,8 +1,8 @@
+import { IntlProvider, Text } from 'preact-i18n';
 import type { TransportMedium } from '../../types/request';
 import t from '../../Utility/i18n';
-import { Text, IntlProvider } from 'preact-i18n';
-import { Radio } from '../Radio';
 import { TRANSPORT_MEDIA } from '../../Utility/requests';
+import { Radio } from '../Radio';
 
 type TransportMediumChooserProps = {
     value: TransportMedium;

--- a/src/Components/I18nWidget.tsx
+++ b/src/Components/I18nWidget.tsx
@@ -1,9 +1,9 @@
 import type { JSX } from 'preact';
-import { useState, useCallback } from 'preact/hooks';
 import { IntlProvider, MarkupText, Text } from 'preact-i18n';
-import { useAppStore, Country } from '../store/app';
-import { useModal } from './Modal';
+import { useCallback, useState } from 'preact/hooks';
+import { Country, useAppStore } from '../store/app';
 import t from '../Utility/i18n';
+import { useModal } from './Modal';
 
 type I18nWidgetProps = {
     minimal: boolean;

--- a/src/Components/MailtoDropdown.tsx
+++ b/src/Components/MailtoDropdown.tsx
@@ -1,10 +1,10 @@
 import type { JSX } from 'preact';
-import { useRef, useCallback } from 'preact/hooks';
-import { Text, IntlProvider } from 'preact-i18n';
-import { useAppStore, Country } from '../store/app';
-import { useModal } from './Modal';
-import t, { t_r } from '../Utility/i18n';
+import { IntlProvider, Text } from 'preact-i18n';
+import { useCallback, useRef } from 'preact/hooks';
 import { RequestLetter } from '../DataType/RequestLetter';
+import { Country, useAppStore } from '../store/app';
+import t, { t_r } from '../Utility/i18n';
+import { useModal } from './Modal';
 
 type EmailData = { email: string; subject: string; body: string };
 type MailtoHandler = (

--- a/src/Components/Modal.tsx
+++ b/src/Components/Modal.tsx
@@ -1,5 +1,5 @@
-import { Fragment, ComponentChildren, JSX } from 'preact';
-import { useState, useCallback, useMemo, useEffect } from 'preact/hooks';
+import { ComponentChildren, Fragment, JSX } from 'preact';
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 import type { MergeExclusive } from 'type-fest';
 import t from '../Utility/i18n';
 

--- a/src/Components/RequestGeneratorBuilder.tsx
+++ b/src/Components/RequestGeneratorBuilder.tsx
@@ -1,14 +1,14 @@
 import type { ComponentChildren } from 'preact';
 import { IntlProvider, MarkupText } from 'preact-i18n';
 import { memo } from 'preact/compat';
-import t from '../Utility/i18n';
-import { Privacy, PRIVACY_ACTIONS } from '../Utility/Privacy';
-import { SvaFinder } from './SvaFinder';
-import { UserRequests } from '../DataType/UserRequests';
 import { useEffect } from 'preact/hooks';
+import { UserRequests } from '../DataType/UserRequests';
 import { useGeneratorStore, useGeneratorStoreApi } from '../store/generator';
 import type { ResponseType } from '../types/request';
+import t from '../Utility/i18n';
+import { Privacy, PRIVACY_ACTIONS } from '../Utility/Privacy';
 import { useModal } from './Modal';
+import { SvaFinder } from './SvaFinder';
 
 type RequestGeneratorBuilderProps = {
     onInitialized?: () => void;

--- a/src/Components/SearchBar.tsx
+++ b/src/Components/SearchBar.tsx
@@ -1,13 +1,13 @@
+import { IntlProvider, MarkupText } from 'preact-i18n';
+import { useEffect, useRef } from 'preact/hooks';
 import type { MergeExclusive } from 'type-fest';
 import type { SearchParams, SearchResponseHit } from 'typesense/lib/Typesense/Documents';
+import { Country, useAppStore } from '../store/app';
 import type { Company } from '../types/company';
-import { useEffect, useRef } from 'preact/hooks';
-import { IntlProvider, MarkupText } from 'preact-i18n';
-import { useAppStore, Country } from '../store/app';
+import { rethrow } from '../Utility/errors';
 import t from '../Utility/i18n';
 import { Privacy, PRIVACY_ACTIONS } from '../Utility/Privacy';
 import { searchClient } from '../Utility/search';
-import { rethrow } from '../Utility/errors';
 import { FeatureDisabledWidget } from './FeatureDisabledWidget';
 
 export type SearchBarProps = {

--- a/src/Components/SvaFinder.tsx
+++ b/src/Components/SvaFinder.tsx
@@ -1,10 +1,10 @@
-import type { SupervisoryAuthority } from '../types/company';
-import { render, Fragment, JSX } from 'preact';
+import deepmerge from 'deepmerge';
+import { Fragment, JSX, render } from 'preact';
 import { useState } from 'preact/hooks';
 import { useAppStore } from '../store/app';
-import t from '../Utility/i18n';
+import type { SupervisoryAuthority } from '../types/company';
 import { fetchSvaDataBySlug } from '../Utility/companies';
-import deepmerge from 'deepmerge';
+import t from '../Utility/i18n';
 
 type SvaFinderProps = {
     callback?: (sva?: SupervisoryAuthority) => void;

--- a/src/Components/Wizard.tsx
+++ b/src/Components/Wizard.tsx
@@ -1,12 +1,12 @@
-import { useState, useEffect } from 'preact/hooks';
-import { Text, MarkupText, IntlProvider } from 'preact-i18n';
-import { useAppStore } from '../store/app';
-import { useFetch } from '../hooks/useFetch';
-import { SearchBar } from './SearchBar';
+import { IntlProvider, MarkupText, Text } from 'preact-i18n';
+import { useEffect, useState } from 'preact/hooks';
 import { SavedCompanies } from '../DataType/SavedCompanies';
+import { useFetch } from '../hooks/useFetch';
+import { useAppStore } from '../store/app';
+import { ErrorException, rethrow } from '../Utility/errors';
 import t from '../Utility/i18n';
-import { rethrow, ErrorException } from '../Utility/errors';
 import { Privacy, PRIVACY_ACTIONS } from '../Utility/Privacy';
+import { SearchBar } from './SearchBar';
 
 const categories = [
     'suggested',

--- a/src/DataType/RequestLetter.ts
+++ b/src/DataType/RequestLetter.ts
@@ -1,6 +1,6 @@
+import { formatAddress, Letter, LetterProps, Template } from 'letter-generator';
+import type { Address, IdDataElement, Request } from '../types/request';
 import t, { t_r } from '../Utility/i18n';
-import { Letter, Template, formatAddress, LetterProps } from 'letter-generator';
-import type { Address, Request, IdDataElement } from '../types/request';
 import { isFieldEmpty } from '../Utility/requests';
 
 type FormattedData = { formatted: string; primary_address: Address | null; name: string };

--- a/src/DataType/SavedCompanies.ts
+++ b/src/DataType/SavedCompanies.ts
@@ -1,5 +1,5 @@
-import localforage from 'localforage';
 import Cookie from 'js-cookie';
+import localforage from 'localforage';
 import { rethrow } from '../Utility/errors';
 
 // TODO: This should probably also be a (persisted) zustand store but since the generator and privacy controls also use

--- a/src/DataType/SavedIdData.ts
+++ b/src/DataType/SavedIdData.ts
@@ -1,10 +1,10 @@
-import type { IdDataElement, Signature } from '../types/request';
-import type { SetOptional } from 'type-fest';
-import { rethrow, WarningException } from '../Utility/errors';
+import { nothing, produce } from 'immer';
 import Cookie from 'js-cookie';
 import LocalForage from 'localforage';
-import { produce, nothing } from 'immer';
-import { isAddress, EMTPY_ADDRESS } from '../Utility/requests';
+import type { SetOptional } from 'type-fest';
+import type { IdDataElement, Signature } from '../types/request';
+import { rethrow, WarningException } from '../Utility/errors';
+import { EMTPY_ADDRESS, isAddress } from '../Utility/requests';
 
 export class SavedIdData {
     localforage_instance: LocalForage;

--- a/src/Utility/browser.ts
+++ b/src/Utility/browser.ts
@@ -1,6 +1,6 @@
-import { parseBcp47Tag, fallback_countries, isSupportedCountry } from './common';
 import type { LiteralUnion } from 'type-fest';
 import type { Country } from '../store/app';
+import { fallback_countries, isSupportedCountry, parseBcp47Tag } from './common';
 
 export const clearUrlParameters = () => {
     window.history.pushState({}, document.title, `${window.BASE_URL}generator`);

--- a/src/Utility/companies.ts
+++ b/src/Utility/companies.ts
@@ -1,6 +1,6 @@
+import type { Company, SupervisoryAuthority } from '../types/company';
 import { ErrorException, rethrow } from './errors';
 import t from './i18n';
-import type { Company, SupervisoryAuthority } from '../types/company';
 
 export function fetchCompanyDataBySlug(slug: string): Promise<Company> {
     return fetch(window.BASE_URL + 'db/' + slug + '.json')

--- a/src/Utility/requests.ts
+++ b/src/Utility/requests.ts
@@ -1,17 +1,17 @@
-import type {
-    IdDataElement,
-    Address,
-    AccessRequest,
-    RequestType,
-    DataFieldName,
-    Request,
-    CustomTemplateName,
-} from '../types/request';
-import type { Company, RequestLanguage, SupervisoryAuthority } from '../types/company';
-import t, { t_r } from './i18n';
-import { CriticalException, rethrow } from './errors';
 import { generateReference } from 'letter-generator';
+import type { Company, RequestLanguage, SupervisoryAuthority } from '../types/company';
+import type {
+    AccessRequest,
+    Address,
+    CustomTemplateName,
+    DataFieldName,
+    IdDataElement,
+    Request,
+    RequestType,
+} from '../types/request';
 import { deepCopyObject } from '../Utility/common';
+import { CriticalException, rethrow } from './errors';
+import t, { t_r } from './i18n';
 
 export const REQUEST_TYPES = ['access', 'erasure', 'rectification', 'objection', 'custom'] as const;
 export const TRANSPORT_MEDIA = ['email', 'letter', 'fax'] as const;

--- a/src/company-list.js
+++ b/src/company-list.js
@@ -1,11 +1,10 @@
-import { render, Component } from 'preact';
 import { SearchBar } from 'Components/SearchBar';
+import { Component, render } from 'preact';
 import { IntlProvider, Text } from 'preact-i18n';
 import PropTypes from 'prop-types';
-
+import Scrollspy from 'react-scrollspy';
 import t from 'Utility/i18n';
 import { Privacy, PRIVACY_ACTIONS } from 'Utility/Privacy';
-import Scrollspy from 'react-scrollspy';
 
 if (!Privacy.isAllowed(PRIVACY_ACTIONS.SEARCH) && document.getElementById('aa-search-input'))
     document.getElementById('aa-search-input').style.display = 'none';

--- a/src/general.tsx
+++ b/src/general.tsx
@@ -1,13 +1,13 @@
-import { render } from 'preact';
 import Cookie from 'js-cookie';
-import { useAppStore, Country } from './store/app';
-import { I18nWidget, I18nButton } from './Components/I18nWidget';
+import { render } from 'preact';
 import { CommentsWidget } from './Components/CommentsWidget';
-import { FlashMessage, flash } from './Components/FlashMessage';
+import { flash, FlashMessage } from './Components/FlashMessage';
 import Footnote from './Components/Footnote';
-import { t_r } from './Utility/i18n';
-import { parameters, parseBcp47Tag, fallback_countries } from './Utility/common';
+import { I18nButton, I18nWidget } from './Components/I18nWidget';
+import { Country, useAppStore } from './store/app';
 import { guessUserCountry } from './Utility/browser';
+import { fallback_countries, parameters, parseBcp47Tag } from './Utility/common';
+import { t_r } from './Utility/i18n';
 
 // Has to run before any rendering, will be removed in prod by bundlers.
 if (process.env.NODE_ENV === 'development') require('preact/debug');

--- a/src/generator.tsx
+++ b/src/generator.tsx
@@ -1,25 +1,25 @@
+import Cookie from 'js-cookie';
 import { render } from 'preact';
 import { IntlProvider, Text } from 'preact-i18n';
-import { clearUrlParameters } from './Utility/browser';
-import t from './Utility/i18n';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 // The type bindings "provided" by this package do not match with the versions of the original package.
 // Since we intend to get rid of this anyway, we will just ignore it.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import Joyride from 'react-joyride';
-import { tutorial_steps } from './wizard-tutorial';
-import Cookie from 'js-cookie';
-import { RequestGeneratorBuilder } from './Components/RequestGeneratorBuilder';
-import { Privacy, PRIVACY_ACTIONS } from './Utility/Privacy';
-import { SavedCompanies } from './DataType/SavedCompanies';
-import { useEffect, useState, useRef, useCallback } from 'preact/hooks';
-import { createGeneratorStore, RequestGeneratorProvider, useGeneratorStore } from './store/generator';
-import { useModal } from './Components/Modal';
 import { ActionButton } from './Components/Generator/ActionButton';
+import { CompanySelector } from './Components/Generator/CompanySelector';
+import { CompanyWidget } from './Components/Generator/CompanyWidget';
 import { NewRequestButton } from './Components/Generator/NewRequestButton';
 import { RequestForm } from './Components/Generator/RequestForm';
-import { CompanyWidget } from './Components/Generator/CompanyWidget';
-import { CompanySelector } from './Components/Generator/CompanySelector';
+import { useModal } from './Components/Modal';
+import { RequestGeneratorBuilder } from './Components/RequestGeneratorBuilder';
+import { SavedCompanies } from './DataType/SavedCompanies';
+import { createGeneratorStore, RequestGeneratorProvider, useGeneratorStore } from './store/generator';
+import { clearUrlParameters } from './Utility/browser';
+import t from './Utility/i18n';
+import { Privacy, PRIVACY_ACTIONS } from './Utility/Privacy';
+import { tutorial_steps } from './wizard-tutorial';
 const HIDE_IN_WIZARD_MODE = [
     '.search',
     '.request-type-chooser',

--- a/src/home.js
+++ b/src/home.js
@@ -1,6 +1,6 @@
+import { Wizard } from 'Components/Wizard';
 import { render } from 'preact';
 import t from 'Utility/i18n';
-import { Wizard } from 'Components/Wizard';
 
 /* modified after https://codepen.io/danielgroen/pen/VeRPOq */
 const hero_rights = [

--- a/src/id-data-controls.tsx
+++ b/src/id-data-controls.tsx
@@ -1,17 +1,17 @@
-import { render } from 'preact';
-import { SavedIdData } from './DataType/SavedIdData';
-import { Privacy, PRIVACY_ACTIONS } from './Utility/Privacy';
-import t from './Utility/i18n';
-import { IntlProvider, MarkupText, Text } from 'preact-i18n';
-import { DynamicInputContainer } from './Components/Generator/DynamicInputContainer';
-import { InputControl } from './Components/Generator/DynamicInput';
-import { SignatureInput } from './Components/Generator/SignatureInput';
-import { FeatureDisabledWidget } from './Components/FeatureDisabledWidget';
-import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
-import type { Address, IdDataElement, Signature } from './types/request';
 import { produce } from 'immer';
-import { isAddress } from './Utility/requests';
+import { render } from 'preact';
+import { IntlProvider, MarkupText, Text } from 'preact-i18n';
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
+import { FeatureDisabledWidget } from './Components/FeatureDisabledWidget';
+import { InputControl } from './Components/Generator/DynamicInput';
+import { DynamicInputContainer } from './Components/Generator/DynamicInputContainer';
+import { SignatureInput } from './Components/Generator/SignatureInput';
+import { SavedIdData } from './DataType/SavedIdData';
+import type { Address, IdDataElement, Signature } from './types/request';
 import { ErrorException } from './Utility/errors';
+import t from './Utility/i18n';
+import { Privacy, PRIVACY_ACTIONS } from './Utility/Privacy';
+import { isAddress } from './Utility/requests';
 
 const DEFAULT_FIXED_FIELDS = {
     name: '',

--- a/src/my-requests.tsx
+++ b/src/my-requests.tsx
@@ -1,13 +1,13 @@
 import { render } from 'preact';
-import { useState, useEffect, useMemo, useCallback } from 'preact/hooks';
-import { IntlProvider, Text, MarkupText } from 'preact-i18n';
-import { useAppStore } from './store/app';
+import { IntlProvider, MarkupText, Text } from 'preact-i18n';
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 import { FeatureDisabledWidget } from './Components/FeatureDisabledWidget';
-import { UserRequests, UserRequest } from './DataType/UserRequests';
+import { UserRequest, UserRequests } from './DataType/UserRequests';
+import { useAppStore } from './store/app';
+import { hash, objFilter } from './Utility/common';
+import { rethrow } from './Utility/errors';
 import t from './Utility/i18n';
 import { Privacy, PRIVACY_ACTIONS } from './Utility/Privacy';
-import { rethrow } from './Utility/errors';
-import { hash, objFilter } from './Utility/common';
 
 const user_requests = new UserRequests();
 

--- a/src/privacy-controls.js
+++ b/src/privacy-controls.js
@@ -1,13 +1,13 @@
-import { render, Component } from 'preact';
-import { IntlProvider, Text, MarkupText } from 'preact-i18n';
+import { Component, render } from 'preact';
+import { IntlProvider, MarkupText, Text } from 'preact-i18n';
+import PropTypes from 'prop-types';
 import t from 'Utility/i18n';
 import { Privacy, PRIVACY_ACTIONS } from 'Utility/Privacy';
-import { UserRequests } from './DataType/UserRequests';
 import Modal from './Components/DeprecatedModal';
-import { SavedIdData } from './DataType/SavedIdData';
+import { flash, FlashMessage } from './Components/FlashMessage';
 import { SavedCompanies } from './DataType/SavedCompanies';
-import { FlashMessage, flash } from './Components/FlashMessage';
-import PropTypes from 'prop-types';
+import { SavedIdData } from './DataType/SavedIdData';
+import { UserRequests } from './DataType/UserRequests';
 
 class PrivacyControl extends Component {
     constructor(props) {

--- a/src/store/company.ts
+++ b/src/store/company.ts
@@ -1,12 +1,12 @@
-import type { Request } from '../types/request';
-import type { Company, SupervisoryAuthority } from '../types/company';
-import type { StoreSlice } from '../types/utility';
-import { RequestState } from './request';
-import { fetchCompanyDataBySlug } from '../Utility/companies';
-import { trackingFields, defaultFields, inferRequestLanguage } from '../Utility/requests';
-import type { GeneratorSpecificState, GeneratorState } from './generator';
 import { produce } from 'immer';
 import { SavedIdData } from '../DataType/SavedIdData';
+import type { Company, SupervisoryAuthority } from '../types/company';
+import type { Request } from '../types/request';
+import type { StoreSlice } from '../types/utility';
+import { fetchCompanyDataBySlug } from '../Utility/companies';
+import { defaultFields, inferRequestLanguage, trackingFields } from '../Utility/requests';
+import type { GeneratorSpecificState, GeneratorState } from './generator';
+import { RequestState } from './request';
 
 export interface CompanyState {
     current_company?: Company | SupervisoryAuthority;

--- a/src/store/generator.ts
+++ b/src/store/generator.ts
@@ -1,17 +1,17 @@
+import create, { GetState, SetState } from 'zustand';
+import createContext from 'zustand/context';
+import { SavedIdData } from '../DataType/SavedIdData';
+import { UserRequests } from '../DataType/UserRequests';
 import type { IdDataElement, Request, ResponseType, Signature } from '../types/request';
 import type { StoreSlice } from '../types/utility';
-import create, { GetState, SetState } from 'zustand';
-import { RequestState, createRequestStore } from './request';
-import { CUSTOM_TEMPLATE_OPTIONS } from '../Utility/requests';
-import createContext from 'zustand/context';
-import { CompanyState, createCompanyStore } from './company';
-import { Privacy, PRIVACY_ACTIONS } from '../Utility/Privacy';
-import { SavedIdData } from '../DataType/SavedIdData';
+import { ErrorException, rethrow } from '../Utility/errors';
 // This will be replaced with an URL by the worker-loader plugin in webpack which is why eslint can't find a default import (TS can be tricked by defining a module).
 // eslint-disable-next-line import/default
 import PdfWorker from '../Utility/pdf.worker.ts';
-import { ErrorException, rethrow } from '../Utility/errors';
-import { UserRequests } from '../DataType/UserRequests';
+import { Privacy, PRIVACY_ACTIONS } from '../Utility/Privacy';
+import { CUSTOM_TEMPLATE_OPTIONS } from '../Utility/requests';
+import { CompanyState, createCompanyStore } from './company';
+import { createRequestStore, RequestState } from './request';
 
 export interface GeneratorSpecificState {
     ready: boolean;

--- a/src/store/request.ts
+++ b/src/store/request.ts
@@ -1,36 +1,36 @@
+import { produce } from 'immer';
+import { Template } from 'letter-generator';
+import { RequestLetter } from '../DataType/RequestLetter';
+import { SavedIdData } from '../DataType/SavedIdData';
+import { UserRequest, UserRequests } from '../DataType/UserRequests';
 import type {
-    Request,
-    IdDataElement,
-    DataFieldName,
-    RequestType,
     Address,
-    TransportMedium,
-    RequestFlag,
-    Signature,
-    CustomTemplateName,
     CustomLetterData,
     CustomRequest,
+    CustomTemplateName,
+    DataFieldName,
+    IdDataElement,
+    Request,
+    RequestFlag,
+    RequestType,
+    Signature,
+    TransportMedium,
 } from '../types/request';
+import type { StoreSlice } from '../types/utility';
+import { slugify } from '../Utility/common';
+import { ErrorException, WarningException } from '../Utility/errors';
+import { t_r } from '../Utility/i18n';
+import { Privacy, PRIVACY_ACTIONS } from '../Utility/Privacy';
 import {
     defaultRequest,
-    REQUEST_FALLBACK_LANGUAGE,
     fetchTemplate,
+    inferRequestLanguage,
     isSaneDataField,
     REQUEST_ARTICLES,
-    inferRequestLanguage,
+    REQUEST_FALLBACK_LANGUAGE,
 } from '../Utility/requests';
-import { UserRequests, UserRequest } from '../DataType/UserRequests';
-import { produce } from 'immer';
-import { RequestLetter } from '../DataType/RequestLetter';
-import { t_r } from '../Utility/i18n';
-import { ErrorException, WarningException } from '../Utility/errors';
-import type { StoreSlice } from '../types/utility';
 import { CompanyState } from './company';
 import type { GeneratorSpecificState, GeneratorState } from './generator';
-import { slugify } from '../Utility/common';
-import { Privacy, PRIVACY_ACTIONS } from '../Utility/Privacy';
-import { SavedIdData } from '../DataType/SavedIdData';
-import { Template } from 'letter-generator';
 
 export interface RequestState<R extends Request> {
     request: R;

--- a/src/suggest-edit.js
+++ b/src/suggest-edit.js
@@ -1,14 +1,14 @@
-import { render, Component, Fragment } from 'preact';
-import Modal from './Components/DeprecatedModal';
-import t from 'Utility/i18n';
-import { fetchCompanyDataBySlug } from './Utility/companies';
-import { slugify, domainWithoutTldFromUrl } from './Utility/common';
 import { parsePhoneNumberFromString } from 'libphonenumber-js';
-require('brutusin-json-forms');
+import { Component, Fragment, render } from 'preact';
+import t from 'Utility/i18n';
+import { searchClient } from 'Utility/search';
+import Modal from './Components/DeprecatedModal';
+import { flash, FlashMessage } from './Components/FlashMessage';
+import { domainWithoutTldFromUrl, slugify } from './Utility/common';
+import { fetchCompanyDataBySlug } from './Utility/companies';
 /* global brutusin */
 import { ErrorException, rethrow } from './Utility/errors';
-import { FlashMessage, flash } from './Components/FlashMessage';
-import { searchClient } from 'Utility/search';
+require('brutusin-json-forms');
 let bf;
 let schema;
 const SUBMIT_URL =

--- a/src/test-interface.tsx
+++ b/src/test-interface.tsx
@@ -1,8 +1,8 @@
 // This file is necessary in order to be able to access interal methods from within the browser tests
 
-import { useAppStore } from './store/app';
-import { FlashMessage, flash } from './Components/FlashMessage';
 import localforage from 'localforage';
+import { flash, FlashMessage } from './Components/FlashMessage';
+import { useAppStore } from './store/app';
 
 type ExtendedWindow = typeof window & {
     getAppStore: () => ReturnType<typeof useAppStore.getState>;

--- a/src/types/company.d.ts
+++ b/src/types/company.d.ts
@@ -1,5 +1,5 @@
-import type { IdDataElement, RequestType, TransportMedium } from './request';
 import type { LiteralUnion, SetOptional } from 'type-fest';
+import type { IdDataElement, RequestType, TransportMedium } from './request';
 
 type RequestLanguage = LiteralUnion<keyof typeof window.I18N_DEFINITION_REQUESTS, string>;
 

--- a/src/types/request.d.ts
+++ b/src/types/request.d.ts
@@ -1,5 +1,5 @@
+import { CUSTOM_TEMPLATE_OPTIONS, REQUEST_TYPES, TRANSPORT_MEDIA } from '../Utility/requests';
 import type { RequestLanguage } from './company';
-import { REQUEST_TYPES, TRANSPORT_MEDIA, CUSTOM_TEMPLATE_OPTIONS } from '../Utility/requests';
 
 export type RequestType = typeof REQUEST_TYPES[number];
 export type TransportMedium = typeof TRANSPORT_MEDIA[number];

--- a/src/types/utility.d.ts
+++ b/src/types/utility.d.ts
@@ -1,4 +1,4 @@
-import type { SetState, GetState } from 'zustand';
+import type { GetState, SetState } from 'zustand';
 
 // taken from https://github.com/pmndrs/zustand/wiki/Splitting-the-store-into-separate-slices
 export type StoreSlice<T extends object, E extends object = T> = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -10065,6 +10065,11 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
+prettier-plugin-organize-imports@^2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.3.4.tgz#65473861ae5ab7960439fff270a2258558fbe9ba"
+  integrity sha512-R8o23sf5iVL/U71h9SFUdhdOEPsi3nm42FD/oDYIZ2PQa4TNWWuWecxln6jlIQzpZTDMUeO1NicJP6lLn2TtRw==
+
 prettier@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.0.tgz#a6370e2d4594e093270419d9cc47f7670488f893"


### PR DESCRIPTION
As we discussed, inconsistent import ordering and having to think about stuff like that are way too annoying. In #898, I didn't agree with where you put the type imports and that finally pushed me over the edge and I went looking for a solution. :D 

I personally would have sorted the imports differently than this plugin but it uses the official TypeScript language service API and I **much** prefer not having to think about the imports at all.

If we actually do care about controlling the sort order (I don't think I do), there's also https://github.com/trivago/prettier-plugin-sort-imports. 