### PR TITLE
Try at fixing flaky search tests

### DIFF
--- a/cypress/integration/company-database/search.spec.js
+++ b/cypress/integration/company-database/search.spec.js
@@ -4,8 +4,9 @@ describe('Search for company by slug and visit company detail page', () => {
     });
 
     it('Search for and visit Facebook single page', () => {
-        cy.get('#aa-search-input').type('facebook');
-        cy.contains('Facebook Ireland Ltd.').click();
+        cy.get('#aa-search-input').type('facebook').blur();
+        // The blur should fix the flaking here: https://github.com/cypress-io/cypress/issues/5830
+        cy.get('.aa-suggestions').contains('Facebook Ireland Ltd.').click();
 
         cy.url().should('include', '/company/facebook');
         cy.title().should('include', 'Facebook Ireland Ltd.');

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -49,7 +49,7 @@ Cypress.Commands.add(
  * Make sure that you are on the homepage and in a tab that can find this company.
  */
 Cypress.Commands.add('addCompanyToWizard', (company, result_str) => {
-    cy.get('#aa-search-input').clear().type(company);
+    cy.get('#aa-search-input').clear().type(company).blur();
     cy.contains(result_str).click();
 });
 


### PR DESCRIPTION
Since the wizard use case tests started flaking with this error message:

```
cy.type() failed because it targeted a disabled element.

The element typed into was:

  > <input id="aa-search-input" class="aa-input-search aa-input" placeholder="Search for “commerce” companies…" type="search" autocomplete="off" spellcheck="false" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-owns="algolia-autocomplete-listbox-0" dir="auto" style="position: relative; vertical-align: top;">

Ensure the element does not have an attribute named disabled before typing into it.
```

I tried to address this by using the workaround suggested in https://github.com/cypress-io/cypress/issues/5830#issuecomment-570638375. Let's see if the updates from #748 will fix it.