### PR TITLE
Workaround for Safari error when creating PdfWorker

### DIFF
--- a/src/Utility/pdf.worker.ts
+++ b/src/Utility/pdf.worker.ts
@@ -1,4 +1,5 @@
 import { PdfRenderer } from 'letter-generator';
+import type { Class } from 'type-fest';
 
 onmessage = (e) => {
     const pdf_renderer = new PdfRenderer(e.data.pdfdoc);
@@ -34,8 +35,4 @@ const vfs_fonts = {
 
 // The Webpack worker-loader plugin will transform this file to have default export that creates the worker but
 // TypeScript doesn't know that, so we introduce this fake export to trick it.
-export default class PdfWorker extends Worker {
-    constructor() {
-        super('');
-    }
-}
+export default undefined as unknown as Class<Worker>;


### PR DESCRIPTION
We've received two error reports concerning PDF generation in Safari:

<details>
<summary>First report</summary>

```
message := Error
type := error
colno := 15014
filename := https://www.datenanfragen.de/js/commons.bundle.gen.js
lineno := 18
error.code := 3
error.message := 
error.description := PdfWorker error
error.name := Error
error.stack := construct@[native code]
construct@[native code]
[i@https://www.datenanfragen.de/js/commons.bundle.gen.js:25:34234](mailto:i@https://www.datenanfragen.de/js/commons.bundle.gen.js:25:34234)
[t@https://www.datenanfragen.de/js/commons.bundle.gen.js:25:32116](mailto:t@https://www.datenanfragen.de/js/commons.bundle.gen.js:25:32116)
construct@[native code]
@https://www.datenanfragen.de/js/commons.bundle.gen.js:18:14834
[n@https://www.datenanfragen.de/js/commons.bundle.gen.js:18:15109](mailto:n@https://www.datenanfragen.de/js/commons.bundle.gen.js:18:15109)
construct@[native code]
@https://www.datenanfragen.de/js/commons.bundle.gen.js:18:14834
[n@https://www.datenanfragen.de/js/commons.bundle.gen.js:18:15733](mailto:n@https://www.datenanfragen.de/js/commons.bundle.gen.js:18:15733)
[value@https://www.datenanfragen.de/js/commons.bundle.gen.js:18:15480](mailto:value@https://www.datenanfragen.de/js/commons.bundle.gen.js:18:15480)
[o@https://www.datenanfragen.de/js/generator.bundle.gen.js:18:7148](mailto:o@https://www.datenanfragen.de/js/generator.bundle.gen.js:18:7148)
error.enduser_message := 
error.context := 
defaultPrevented := false
eventPhase := 2
isTrusted := true
returnValue := true
code_version := 1.0.0
user_agent := Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.5 Safari/605.1.15
url.href := https://www.datenanfragen.de//generator#!from=wizard
url.protocol := https:
url.host := [www.datenanfragen.de](http://www.datenanfragen.de/)
url.hostname := [www.datenanfragen.de](http://www.datenanfragen.de/)
url.port := 
url.pathname := //generator
url.search := 
url.hash := #!from=wizard
url.origin := https://www.datenanfragen.de/
```

</details>



<details>
<summary>Second report</summary>

```
message := Error
type := error
colno := 15014
filename := https://www.datarequests.org/js/commons.bundle.gen.js
lineno := 18
error.code := 3
error.message := 
error.description := PdfWorker error
error.name := Error
error.stack := construct@[native code]
construct@[native code]
i@https://www.datarequests.org/js/commons.bundle.gen.js:25:34234
t@https://www.datarequests.org/js/commons.bundle.gen.js:25:32116
construct@[native code]
https://www.datarequests.org/js/commons.bundle.gen.js:18:14834
n@https://www.datarequests.org/js/commons.bundle.gen.js:18:15109
construct@[native code]
https://www.datarequests.org/js/commons.bundle.gen.js:18:14834
n@https://www.datarequests.org/js/commons.bundle.gen.js:18:15733
value@https://www.datarequests.org/js/commons.bundle.gen.js:18:15480
o@https://www.datarequests.org/js/generator.bundle.gen.js:18:7023
error.enduser_message := 
error.context := 
defaultPrevented := false
eventPhase := 2
isTrusted := true
returnValue := true
code_version := 1.0.0
user_agent := Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Safari/605.1.15
url.href := https://www.datarequests.org/generator/
url.protocol := https:
url.host := www.datarequests.org
url.hostname := www.datarequests.org
url.port := 
url.pathname := /generator/
url.search := 
url.hash := 
url.origin := https://www.datarequests.org
```

</details>

The error happens immediately when the `PdfWorker` is loaded. I don't understand why the error occurs. I especially don't understand what changes could have lead to this error.

But this workaround seems to solve the problem. \*shrug* 