### PR TITLE
Custom reqs for tracking companies: Bugfix for unset sender address

### DIFF
--- a/src/store/request.ts
+++ b/src/store/request.ts
@@ -420,5 +420,7 @@ function makeCustomDataFromIdData(request: CustomRequest) {
         if (f.type === 'name') custom_data.name = f.value;
         if (f.type === 'address' && f.value.primary) custom_data.sender_address = f.value;
     });
+    if (!custom_data.sender_address)
+        custom_data.sender_address = { street_1: '', street_2: '', place: '', country: '' };
     return custom_data;
 }


### PR DESCRIPTION
We've received the following error report:

<details>
<summary>Details</summary>

```
message := Uncaught TypeError: Cannot read properties of undefined (reading 'street_1')
type := error
colno := 2350
filename := https://www.datarequests.org/js/generator.bundle.gen.js
lineno := 18
error.message := Cannot read properties of undefined (reading 'street_1')
error.name := TypeError
error.stack := TypeError: Cannot read properties of undefined (reading 'street_1')
at Function.value (https://www.datarequests.org/js/generator.bundle.gen.js:18:2350)
at Object.letter (https://www.datarequests.org/js/generator.bundle.gen.js:18:15359)
at renderLetter (https://www.datarequests.org/js/generator.bundle.gen.js:18:7330)
at https://www.datarequests.org/js/generator.bundle.gen.js:19:36965
at https://www.datarequests.org/js/commons.bundle.gen.js:25:21923
at Set.forEach (<anonymous>)
at r (https://www.datarequests.org/js/commons.bundle.gen.js:25:21895)
at setRequestType (https://www.datarequests.org/js/generator.bundle.gen.js:18:10300)
at Object.onChange (https://www.datarequests.org/js/generator.bundle.gen.js:19:42193)
at Object.onChange [as changefalse] (https://www.datarequests.org/js/generator.bundle.gen.js:19:9097)
error.context :=
defaultPrevented := false
eventPhase := 2
isTrusted := true
returnValue := true
code_version := 1.0.0
url.href := https://www.datarequests.org/generator
url.origin := https://www.datarequests.org/
url.protocol := https:
url.host := [www.datarequests.org](http://www.datarequests.org/)[<http://www.datarequests.org>](http://www.datarequests.org/)
url.hostname := [www.datarequests.org](http://www.datarequests.org/)[<http://www.datarequests.org>](http://www.datarequests.org/)
url.port :=
url.pathname := /generator
url.search :=
url.hash := 
```

</details>

The error happens when trying the generate a custom request for a tracking company. The problem was that we assumed `custom_data.sender_address` is set even though it wasn't for tracking companies.