### PR TITLE
Don't error if user has disabled all site storage in their browser

### DIFF
--- a/src/Utility/Privacy.ts
+++ b/src/Utility/Privacy.ts
@@ -14,17 +14,17 @@ export const PRIVACY_ACTIONS: Record<string, PrivacyAction> = {
     },
     SAVE_MY_REQUESTS: {
         id: 'save_my_requests',
-        default: true,
+        default: navigator.cookieEnabled,
         dnt: true,
     },
     SAVE_ID_DATA: {
         id: 'save_id_data',
-        default: true,
+        default: navigator.cookieEnabled,
         dnt: true,
     },
     SAVE_WIZARD_ENTRIES: {
         id: 'save_wizard_entries',
-        default: true,
+        default: navigator.cookieEnabled,
         dnt: true,
     },
     // TELEMETRY: {


### PR DESCRIPTION
We received an error report where most of our pages were unusable due
to a "No available storage method found" error from localForage. As the
message implies, this error occurs if the user has disabled _all_ site
storage in their browser and localForage can't find any backend to
write to.

I was able to reproduce this both in Chrome and Firefox. In Chrome, you
can disable all site storage by going to chrome://settings/cookies and
choosing "Block all cookies (not recommended)". In Firefox, it's more
hidden and per-site. Open the site and press Ctrl + I to open the "Page
Info" dialog. Click "Permissions" and disable "Set cookies".

Obviously, disabling site storage shouldn't make our site fail. After
all, we even explicitly allow users to turn that off on our site! Thus,
the solution is quite simple: Instead of defaulting to "true" for the
corresponding privacy controls, we should default according to whether
the user has enabled site storage.

Since all browsers seem to tie disabling localStorage et al. to
disabling cookies, we can just check whether cookies are enabled for
this feature detection and there's the very handy
`navigator.cookieEnabled` property for that.