### PR TITLE
Properly handle VersionError in PrivacyAsyncStorage

### DIFF
--- a/src/error-handler.js
+++ b/src/error-handler.js
@@ -100,10 +100,6 @@ try {
                 return;
             }
 
-            // Ignore annoying idb error on first load, which seems to be harmless. TODO: Fix this properly.
-            if (/The requested version (\d+) is less than the existing version (\d+)/.match(event.error?.message || ''))
-                return;
-
             if (event.error?.no_side_effects && isNetworkError(event.error.message)) {
                 if (!window.navigator.onLine) {
                     // seems like we don't have a network connection in the first place


### PR DESCRIPTION
The `VersionError`is mainly an artefact because we (and localforage) use IndexedDB a little hacky. Normally, you are supposed to plan out your database in advance and change the version in the code every time your database schema changes. But since, we create the schema dynamically and we share a database with localforage, this is no possible and we run into these problems, where we have to adjust the version sometimes.