### PR TITLE
Add some simple tests for the app and proceedings page

### DIFF
--- a/cypress/integration/components/app.spec.js
+++ b/cypress/integration/components/app.spec.js
@@ -1,0 +1,59 @@
+describe('Request generator tool component', () => {
+    it('sets correct request type and shows flags', () => {
+        const types = [
+            { type: 'access', buttonText: 'access', flagTexts: [] },
+            {
+                type: 'erasure',
+                buttonText: 'Delete',
+                flagTexts: ['Erase all data', 'Additionally include an objection'],
+            },
+            { type: 'rectification', buttonText: 'Correct', flagTexts: ['Correct data'] },
+            { type: 'objection', buttonText: 'direct marketing', flagTexts: [] },
+        ];
+
+        for (const type of types) {
+            cy.visit('/generator');
+
+            cy.contains(type.buttonText).click();
+            cy.generatorStore()
+                .then((state) => state.batchRequestType)
+                .should('be.equal', type.type);
+
+            cy.searchAndRequestCompanies(['Reddit', 'Datenanfragen']);
+
+            cy.generatorStore()
+                .then((state) => state.request.type)
+                .should('be.equal', type.type);
+            for (const flagText of type.flagTexts) cy.get('#app').contains(flagText).should('be.visible');
+
+            cy.contains('Send request').click();
+            cy.contains('Skip request').click({ force: true });
+
+            cy.generatorStore()
+                .then((state) => state.request.type)
+                .should('be.equal', type.type);
+            for (const flagText of type.flagTexts) cy.get('#app').contains(flagText).should('be.visible');
+        }
+    });
+
+    it('loads pdf worker for pdf only companies', () => {
+        cy.visit('/generator');
+
+        cy.contains('access').click();
+        cy.searchAndRequestCompanies(['Instagram']);
+        cy.window().then((win) => {
+            expect(win.pdfWorker).not.to.be.undefined;
+            expect(win.pdfWorker).to.satisfy((o) => o instanceof win.Worker);
+        });
+    });
+
+    it('does not load pdf worker by default', () => {
+        cy.visit('/generator');
+
+        cy.contains('access').click();
+        cy.searchAndRequestCompanies(['Netflix']);
+        cy.window().then((win) => {
+            expect(win.pdfWorker).to.be.undefined;
+        });
+    });
+});

--- a/cypress/integration/components/proceedings.spec.js
+++ b/cypress/integration/components/proceedings.spec.js
@@ -1,0 +1,79 @@
+const message_template = {
+    reference: '2022-KKD2YF1',
+    date: new Date(),
+    type: 'access',
+    slug: 'datenanfragen',
+    correspondent_address: 'Datenanfragen.de e. V.\nSchreinerweg 6\n38126 Braunschweig\nDeutschland',
+    correspondent_email: 'datenschutz@datenanfragen.de',
+    transport_medium: 'email',
+    subject: undefined,
+    content: undefined,
+    sentByMe: true,
+    extra: undefined,
+};
+
+describe('Proceedings page', () => {
+    beforeEach(() => {
+        cy.clearIndexedDb('Datenanfragen.de');
+        cy.visit('/my-requests');
+        // Wait for proceedingsStore hydration TODO: Can this be more elegant? This seems bound to be undeterministic
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(100);
+
+        cy.proceedingsStore()
+            .then((state) => state._hasHydrated)
+            .should('be.equal', true);
+    });
+
+    it('shows regular proceeding', () => {
+        cy.proceedingsStore().then((store) =>
+            store.addProceeding({
+                reference: '2022-KKD2YF1',
+                state: 'done',
+                messages: {
+                    '2022-KKD2YF1-00': {
+                        id: '2022-KKD2YF1-00',
+                        ...message_template,
+                    },
+                },
+            })
+        );
+        cy.get('.proceeding-rows')
+            .should('contain.text', '2022-KKD2YF1')
+            .should('contain.text', 'Datenanfragen.de e. V.');
+    });
+
+    it('assigns correct state', () => {
+        cy.proceedingsStore().then((store) => {
+            store.addProceeding({
+                reference: '2022-KKD2YF1',
+                messages: {},
+            });
+            store.addMessage({
+                ...message_template,
+                date: new Date('2022-01-14T00:00:00.000Z'),
+            });
+        });
+        cy.get('.proceeding-rows').should('contain.text', 'Overdue').should('contain.text', '14 January 2022');
+
+        cy.proceedingsStore().then((store) => {
+            store.addMessage({
+                ...message_template,
+                type: 'response',
+                sentByMe: false,
+            });
+        });
+
+        cy.get('.proceeding-rows').should('contain.text', 'Action needed');
+
+        cy.proceedingsStore().then((store) => {
+            store.addMessage({
+                ...message_template,
+                type: 'admonition',
+                sentByMe: true,
+            });
+        });
+
+        cy.get('.proceeding-rows').should('contain.text', 'Response pending');
+    });
+});

--- a/cypress/integration/use-cases/migration.spec.js
+++ b/cypress/integration/use-cases/migration.spec.js
@@ -54,11 +54,11 @@ describe('Saved requests in the legacy database should be correctly migrated', (
 
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(500);
-        cy.window()
-            .then((win) => win.getProceedingsStore()._migratedLegacyRequests)
+        cy.proceedingsStore()
+            .then((state) => state._migratedLegacyRequests)
             .should('be.equal', true);
-        cy.window()
-            .then((win) => win.getProceedingsStore().proceedings)
+        cy.proceedingsStore()
+            .then((state) => state.proceedings)
             .should('haveOwnProperty', reference)
             .then((proceedings) => proceedings[reference])
             .should('deep.equal', {
@@ -115,11 +115,11 @@ describe('Saved requests in the legacy database should be correctly migrated', (
 
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(500);
-        cy.window()
-            .then((win) => win.getProceedingsStore()._migratedLegacyRequests)
+        cy.proceedingsStore()
+            .then((state) => state._migratedLegacyRequests)
             .should('be.equal', true);
-        cy.window()
-            .then((win) => win.getProceedingsStore().proceedings)
+        cy.proceedingsStore()
+            .then((state) => state.proceedings)
             .should('haveOwnProperty', reference)
             .then((proceedings) => proceedings[reference])
             .should('deep.equal', {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -87,3 +87,14 @@ Cypress.Commands.add('seedWizardCompaniesWithKnownList', () => {
             cy.get('#wizard').scrollIntoView();
         });
 });
+
+Cypress.Commands.add('generatorStore', () => cy.window().then((win) => win.generatorStoreApi.getState()));
+Cypress.Commands.add('proceedingsStore', () => cy.window().then((win) => win.getProceedingsStore()));
+Cypress.Commands.add('searchAndRequestCompanies', (searchTerms) => {
+    for (const search of searchTerms) {
+        cy.get('.ais-SearchBox-input').clear().type(search);
+        cy.get('.company-result-content').contains(search).click();
+    }
+    cy.get('#review-n-companies-button').click();
+    cy.contains('Continue with these companies').click();
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,7 +25,7 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 import '@percy/cypress';
-
+import '@this-dot/cypress-indexeddb';
 /**
  * Click a link without following its `href`. This is useful for `mailto` links and file downloads as Cypress doesn't
  * support those.

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
         "@babel/runtime": "^7.6.2",
         "@cypress/skip-test": "^2.5.0",
         "@percy/cypress": "^2.2.0",
+        "@this-dot/cypress-indexeddb": "^1.1.3",
         "@types/fs-extra": "^9.0.13",
         "@types/js-cookie": "^3.0.1",
         "@types/preact-i18n": "^2.3.0-preactx",

--- a/src/Components/App/CompanySearchPage.tsx
+++ b/src/Components/App/CompanySearchPage.tsx
@@ -460,6 +460,7 @@ export const CompanySearchPage = (props: CompanySearchPageProps) => {
                 <div className="app-cta-container">
                     <CustomCompanyButton />
                     <button
+                        id="review-n-companies-button"
                         className="button button-primary"
                         disabled={batch_length < 1}
                         onClick={() => props.setPage('review_selection')}>

--- a/src/Components/Generator/ActionButton.tsx
+++ b/src/Components/Generator/ActionButton.tsx
@@ -18,7 +18,6 @@ export const ActionButton = (_props: ActionButtonProps) => {
     const email = useGeneratorStore((state) => state.request.email);
     const transport_medium = useGeneratorStore((state) => state.request.transport_medium);
     const request_sent = useGeneratorStore((state) => state.request.sent);
-    const request_reference = useGeneratorStore((state) => state.request.reference);
     const ready = useGeneratorStore((state) => state.ready);
     const download_active = useGeneratorStore((state) => state.download_active);
     const download_url = useGeneratorStore((state) => state.download_url);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,22 @@
 import { render } from 'preact';
-import { createGeneratorStore, RequestGeneratorProvider } from './store/generator';
+import { createGeneratorStore, RequestGeneratorProvider, useGeneratorStoreApi } from './store/generator';
 import { App } from './Components/App/App';
 import { Reactor } from './Components/Reactor/Reactor';
+import { useEffect } from 'preact/hooks';
+
+// Expose the store for the test interface
+const GeneratorStoreTestInterface = () => {
+    const generatorStoreApi = useGeneratorStoreApi();
+
+    useEffect(() => {
+        if (process.env.NODE_ENV === 'development') {
+            (window as typeof window & { generatorStoreApi: typeof generatorStoreApi }).generatorStoreApi =
+                generatorStoreApi;
+        }
+    });
+
+    return <></>;
+};
 
 const elem = document.querySelector('main');
 if (elem) {
@@ -10,6 +25,7 @@ if (elem) {
             <Reactor reference={window.PARAMETERS.reference} />
         ) : (
             <RequestGeneratorProvider createStore={createGeneratorStore}>
+                {process.env.NODE_ENV === 'development' && <GeneratorStoreTestInterface />}
                 <App />
             </RequestGeneratorProvider>
         ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1810,6 +1810,11 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
+"@this-dot/cypress-indexeddb@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@this-dot/cypress-indexeddb/-/cypress-indexeddb-1.1.3.tgz#59af13ed8866772e4f97eb00bfcb27d28bdcae78"
+  integrity sha512-OBavqHwds8Wwvm+8/9HBIVTKChWUuIqeGRVzLQh2driDdzmJ9Tzoi6lRmlT/kDFaqmqqj3ZzzBB9UpLNnpUBCA==
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"


### PR DESCRIPTION
The tests are still failing because the old generator is not at `/generator`, so we should decide what happens to them after #935 is resolved. Also, the app tests are not really "component" tests, I am unsure how to classify them.

Depends on #934 so that the new migration test doesn't fail, so please merge that first.