### PR TITLE
Enforce /generator as slug for all translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ While you can just contribute translations through this repository, an easier wa
 
 If you're interested in chatting about our translation efforts, join our [i18n room on Matrix](https://matrix.to/#/#dade-i18n:matrix.altpeter.me).
 
+Notice to translators: When adding a new language, the `slug` of the `generator.md` page must not be translated, as our redirection code depends on it.
+
 <!-- 
 TODO:
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ While you can just contribute translations through this repository, an easier wa
 
 If you're interested in chatting about our translation efforts, join our [i18n room on Matrix](https://matrix.to/#/#dade-i18n:matrix.altpeter.me).
 
-Notice to translators: When adding a new language, the `slug` of the `generator.md` page must not be translated, as our redirection code depends on it.
-
 <!-- 
 TODO:
 

--- a/content/es/generator.md
+++ b/content/es/generator.md
@@ -5,6 +5,6 @@
     "description": "Usa nuestro generador para crear solicitudes RGPD de forma fácil y gratuita y ejerce tus derechos.",
     "featured_image_url": "/img/card/generator-es.png",
     "tags": [ "datarequests", "rgpd", "reglamento general de protección de datos", "generador de solicitud", "privacidad" ],
-    "slug": "generador",
-    "aliases": ["generator"]
+    "slug": "generator",
+    "aliases": ["generador"]
 }

--- a/content/es/generator.md
+++ b/content/es/generator.md
@@ -5,6 +5,5 @@
     "description": "Usa nuestro generador para crear solicitudes RGPD de forma fácil y gratuita y ejerce tus derechos.",
     "featured_image_url": "/img/card/generator-es.png",
     "tags": [ "datarequests", "rgpd", "reglamento general de protección de datos", "generador de solicitud", "privacidad" ],
-    "slug": "generator",
     "aliases": ["generador"]
 }

--- a/content/pt/generator.md
+++ b/content/pt/generator.md
@@ -2,6 +2,5 @@
     "title": "Gerador de solicitação",
     "type": "generator",
     "static": true,
-    "slug": "generator",
     "aliases": ["gerador"]
 }

--- a/content/pt/generator.md
+++ b/content/pt/generator.md
@@ -2,6 +2,6 @@
     "title": "Gerador de solicitação",
     "type": "generator",
     "static": true,
-    "slug": "gerador",
-    "aliases": ["generator"]
+    "slug": "generator",
+    "aliases": ["gerador"]
 }

--- a/src/Components/RequestList.tsx
+++ b/src/Components/RequestList.tsx
@@ -403,8 +403,6 @@ export const ProceedingRow = (props: ProceedingRowProps) => {
                                 <a
                                     className="button button-small button-primary"
                                     style="word-wrap: unset;"
-                                    // TODO: This is broken for the language versions that redirect their /generator to
-                                    // something else.
                                     href={`${window.BASE_URL}generator#!reference=${props.proceeding.reference}`}
                                     onClick={(e) => {
                                         if (props.onReact) {

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -20,3 +20,7 @@
 * Mention the new domain in the `README`.
 * Add the domain in dattel (see `infrastructure` on how to do that) and set the appropriate DNS records.
 * In `deploy-dattel.js`, add the new language to the `languages` array and trigger a deploy using `CONTEXT=production ./deploy.sh && yarn deploy-dattel`.
+
+## Notes
+
+* When adding a new language, the `slug` of the `generator.md` page must not be translated, as our redirection code depends on it.


### PR DESCRIPTION
Against our previous practice, we decided to enforce the slug of the generator page to stay `generator` in all languages, because redirects from other languages would break the URL parameters. We found this to be the least technically invasive solution. It is still possible to translate the slug in the `alias` section of the frontmatter, but note that these URLs will not support URL parameters.

Sorry to the translators who cared about the translated URLs and people who used the different links previously.