### PR TITLE
Fix tests failing due to Facebook rename

### DIFF
--- a/cypress/integration/company-database/search.spec.js
+++ b/cypress/integration/company-database/search.spec.js
@@ -3,12 +3,12 @@ describe('Search for company by slug and visit company detail page', () => {
         cy.visit('/company');
     });
 
-    it('Search for and visit Facebook single page', () => {
-        cy.get('#aa-search-input').type('facebook').blur();
+    it('Search for and visit 1&1 single page', () => {
         // The blur should fix the flaking here: https://github.com/cypress-io/cypress/issues/5830
-        cy.get('.aa-suggestions').contains('Facebook Ireland Ltd.').click();
+        cy.get('#aa-search-input').type('1&1').blur();
+        cy.get('.aa-suggestions').contains('1&1 Internet SE').click();
 
-        cy.url().should('include', '/company/facebook');
-        cy.title().should('include', 'Facebook Ireland Ltd.');
+        cy.url().should('include', '/company/1und1');
+        cy.title().should('include', '1&1 Internet SE');
     });
 });

--- a/cypress/integration/components/generator.spec.js
+++ b/cypress/integration/components/generator.spec.js
@@ -59,13 +59,13 @@ describe('Generator component', () => {
     it('loads company from slug', () => {
         cy.visit('/generator/#!company=facebook');
         cy.reload();
-        cy.contains('Facebook Ireland Ltd.');
+        cy.contains('Meta Platforms Ireland Limited');
     });
 
     it('loads companies from slug', () => {
         cy.visit('/generator/#!companies=facebook,google');
         cy.reload();
-        cy.contains('Facebook Ireland Ltd.');
+        cy.contains('Meta Platforms Ireland Limited');
         cy.contains('Next request').click();
         cy.contains('New request').click();
         cy.contains('Google LLC');


### PR DESCRIPTION
"Facebook Ireland Ltd." became "Meta Platforms Ireland Limited". Some of our tests depend on that name.

This is currently preventing any new changes from going live.

In the search test, I switched to another company since Oculus now has the same company name as Facebook, so it's easier to just use a company that only has one record.