### PR TITLE
Fixes #960: Filter out errors in Safari extensions

### DIFF
--- a/src/error-handler.js
+++ b/src/error-handler.js
@@ -95,6 +95,7 @@ try {
                     'safari-extension://',
                     '@safari-web-extension://',
                     'ms-browser-extension://',
+                    '@webkit-masked-url://hidden/',
                 ].some((s) => event.error?.stack?.includes(s))
             ) {
                 return;


### PR DESCRIPTION
Filter out error where the stack includes `@webkit-masked-url://hidden/` that seems to correlate with extension errors.