### PR TITLE
Delete left-over .percy.yml

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -1,3 +1,0 @@
-version: 1
-snapshot:
-  widths: [375, 1920]


### PR DESCRIPTION
We got rid of Percy in e7afa69fd44f1431ce3a81ae17442ae904e41287 but forgot this file.