### PR TITLE
Add proper context to rethrow in PrivacyAsyncStorage

### DIFF
--- a/src/Utility/PrivacyAsyncStorage.ts
+++ b/src/Utility/PrivacyAsyncStorage.ts
@@ -1,6 +1,7 @@
 import { IDBPDatabase, openDB } from 'idb';
 import type { SetOptional } from 'type-fest';
 import { rethrow } from './errors';
+import t from './i18n';
 
 export type PrivacyAsyncStorageOption = {
     /** Name of the database */
@@ -63,7 +64,14 @@ export class PrivacyAsyncStorage {
                                 : (this.#options.version || 1) + 1;
                             return;
                         }
-                        rethrow(e);
+                        rethrow(
+                            e,
+                            'Unexpected error while opening IndexedDB in PrivacyAsyncStorage.getDb',
+                            {
+                                options: this.#options,
+                            },
+                            t('indexeddb-error', 'error-msg')
+                        );
                     })
                     .then((db) => {
                         if (db && !db.objectStoreNames.contains(this.#options.storeName)) {
@@ -141,7 +149,7 @@ export class PrivacyAsyncStorage {
                 db?.close();
                 return;
             }
-            rethrow(e);
+            rethrow(e, 'Error in doesStoreExist', { name, storeName, db }, t('indexeddb-error', 'error-msg'));
         });
 
         if (db) {

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -518,7 +518,8 @@
     },
     "error-msg": {
         "company-not-found": "Das gewünschte Unternehmen wurde nicht gefunden.",
-        "sva-not-found": "Beim Laden der Informationen zu der Datenschutz-Aufsichtsbehörde ist ein Fehler aufgetreten."
+        "sva-not-found": "Beim Laden der Informationen zu der Datenschutz-Aufsichtsbehörde ist ein Fehler aufgetreten.",
+        "indexeddb-error": "Beim Zugreifen auf die Datenbank in Deinem Browser ist ein unerwarteter Fehler aufgetreten."
     },
     "suggest": {
         "success": "Dein Vorschlag wurde erfolgreich abgesendet. Vielen Dank noch einmal! Wir werden ihn jetzt schnellstmöglich überprüfen.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -517,7 +517,8 @@
     },
     "error-msg": {
         "company-not-found": "The company you were looking for could not be found.",
-        "sva-not-found": "Loading the data on the supervisory authority failed."
+        "sva-not-found": "Loading the data on the supervisory authority failed.",
+        "indexeddb-error": "An unexpected error occured while trying to access the database in your browser."
     },
     "suggest": {
         "success": "Your contribution has been sent successfully. Thank you! We will now review it as soon as possible.",


### PR DESCRIPTION
In #1014, we found that proper error messages were missing from PrivacyAsyncStorage, which made it harder to debug. I added those now.