### PR TITLE
I18N: Switch language to onChange and not onBlur

### DIFF
--- a/src/Components/I18nWidget.tsx
+++ b/src/Components/I18nWidget.tsx
@@ -27,7 +27,7 @@ export const I18nWidget = (props: I18nWidgetProps) => {
         ),
         negativeText: <Text id="stay" />,
         onNegativeFeedback: () => {
-            setNewLanguage(savedLocale);
+            setNewLanguage(savedLocale); // TODO: Is this call needed?
             dismissModal();
         },
         hasDismissButton: false,
@@ -71,7 +71,7 @@ export const I18nWidget = (props: I18nWidgetProps) => {
                         <Text id="language" />
                     </h2>
                     <div className="select-container">
-                        <select value={savedLocale} onBlur={changeLanguage}>
+                        <select value={savedLocale} onChange={changeLanguage}>
                             <option value={savedLocale}>
                                 <Text id={`language-desc-${savedLocale}`} />
                             </option>

--- a/src/Components/I18nWidget.tsx
+++ b/src/Components/I18nWidget.tsx
@@ -27,7 +27,8 @@ export const I18nWidget = (props: I18nWidgetProps) => {
         ),
         negativeText: <Text id="stay" />,
         onNegativeFeedback: () => {
-            setNewLanguage(savedLocale); // TODO: Is this call needed?
+			// Reset the select to show the current language instead of the just selected one.
+            setNewLanguage(savedLocale); 
             dismissModal();
         },
         hasDismissButton: false,


### PR DESCRIPTION
Fixes #977. Previously the change would only occur on blur, making the website feel sluggish and unresponsive. This restores the pre- new_ux-behviour.