### PR TITLE
Add trackers.tweasel.org to the privacy policy

### DIFF
--- a/content/de/privacy.md
+++ b/content/de/privacy.md
@@ -23,7 +23,7 @@ Diese Datenschutzerklärung gilt für alle Aktivitäten des Datenanfragen.de e.&
 
 Dazu zählen zunächst die Daten, die wir von unseren Mitgliedern erheben und verarbeiten, aber auch jene die anfallen, wenn Du z.&nbsp;B. an uns spendest.
 
-Weiterhin gilt die Datenschutzerklärung für unsere Webseiten [Datenanfragen.de](https://www.datenanfragen.de), [datarequests.org](https://www.datarequests.org), [demandetesdonnees.fr](https://www.demandetesdonnees.fr), [solicituddedatos.es](https://www.solicituddedatos.es), [osobnipodaci.org](https://www.osobnipodaci.org), [gegevensaanvragen.nl](https://www.gegevensaanvragen.nl) und [pedidodedados.org](https://www.pedidodedados.org/).
+Weiterhin gilt die Datenschutzerklärung für unsere Webseiten [Datenanfragen.de](https://www.datenanfragen.de), [datarequests.org](https://www.datarequests.org), [demandetesdonnees.fr](https://www.demandetesdonnees.fr), [solicituddedatos.es](https://www.solicituddedatos.es), [osobnipodaci.org](https://www.osobnipodaci.org), [gegevensaanvragen.nl](https://www.gegevensaanvragen.nl), [pedidodedados.org](https://www.pedidodedados.org/) und [trackers.tweasel.org](https://trackers.tweasel.org).
 
 Zweck des Datenanfragen.de e.&nbsp;V. ist es, die Bürger_innen durch Aufklärung und Beratung in allen mit dem Datenschutz im Zusammenhang stehenden Fragen in der Ausübung ihres Rechts auf informationelle Selbstbestimmung zu stärken. Wir sind in allen unseren Tätigkeiten an unsere {{< link slug="verein/constitution" text="Satzung" >}} gebunden.
 

--- a/content/en/privacy.md
+++ b/content/en/privacy.md
@@ -23,7 +23,7 @@ This privacy policy applies to all activities of Datenanfragen.de e.&nbsp;V. (�
 
 This includes the data we collect and process from our member but also the data that is incurred from donations and the like.
 
-In addition, this includes our websites [Datenanfragen.de](https://www.datenanfragen.de), [datarequests.org](https://www.datarequests.org), [demandetesdonnees.fr](https://www.demandetesdonnees.fr), [solicituddedatos.es](https://www.solicituddedatos.es), [osobnipodaci.org](https://www.osobnipodaci.org), [gegevensaanvragen.nl](https://www.gegevensaanvragen.nl) and [pedidodedados.org](https://www.pedidodedados.org/).
+In addition, this includes our websites [Datenanfragen.de](https://www.datenanfragen.de), [datarequests.org](https://www.datarequests.org), [demandetesdonnees.fr](https://www.demandetesdonnees.fr), [solicituddedatos.es](https://www.solicituddedatos.es), [osobnipodaci.org](https://www.osobnipodaci.org), [gegevensaanvragen.nl](https://www.gegevensaanvragen.nl), [pedidodedados.org](https://www.pedidodedados.org/) and [trackers.tweasel.org](https://trackers.tweasel.org).
 
 The association's purpose is to support the general public in exercising their right to privacy (“right to informational self-determination”) by informing and advising them with all questions regarding personal data protection. We are bound by our {{< link slug="verein/constitution" text="constitution" >}} in all our activities.
 

--- a/content/es/privacy.md
+++ b/content/es/privacy.md
@@ -23,7 +23,7 @@ Esta política de privacidad se aplica a todas las actividades de Datenanfragen.
 
 Esto incluye los datos que recopilamos y procesamos de nuestros miembros, pero también los datos que se obtienen de donaciones y similares.
 
-Además, esto incluye nuestros sitios web [solicituddedatos.es](https://www.solicituddedatos.es), [Datenanfragen.de](https://www.datenanfragen.de), [datarequests.org](https://www.datarequests.org), [demandetesdonnees.fr](https://www.demandetesdonnees.fr), [osobnipodaci.org](https://www.osobnipodaci.org), [gegevensaanvragen.nl](https://www.gegevensaanvragen.nl) y [pedidodedados.org](https://www.pedidodedados.org/).
+Además, esto incluye nuestros sitios web [solicituddedatos.es](https://www.solicituddedatos.es), [Datenanfragen.de](https://www.datenanfragen.de), [datarequests.org](https://www.datarequests.org), [demandetesdonnees.fr](https://www.demandetesdonnees.fr), [osobnipodaci.org](https://www.osobnipodaci.org), [gegevensaanvragen.nl](https://www.gegevensaanvragen.nl), [pedidodedados.org](https://www.pedidodedados.org/) y [trackers.tweasel.org](https://trackers.tweasel.org).
 
 El propósito de la asociación es ayudar al público en general a ejercer su derecho a la privacidad (“derecho a la autodeterminación informativa”) informándoles y asesorándolos con todas las preguntas relacionadas con la protección de datos personales. Estamos sujetos a nuestra {{< link slug="verein/constitution" text="constitución" >}} en todas nuestras actividades.
 


### PR DESCRIPTION
We are launching the new tracker wiki under at trackers.tweasel.org, but since the hosting is identical, we can just use the privacy policy.

Wait to merge this until after the deploy.