### PR TITLE
Comments: Expand regex for detecting wrongly addressed comments

### DIFF
--- a/src/Components/CommentsWidget.tsx
+++ b/src/Components/CommentsWidget.tsx
@@ -178,19 +178,19 @@ export function CommentForm(props: CommentFormProps) {
             return false;
         }
 
+        // Names are not allowed to contain email addresses.
+        if (author.includes('@')) {
+            flash(<FlashMessage type="error">{t('no-email-in-name', 'comments')}</FlashMessage>);
+            return;
+        }
         // Warn users who probably want to send a message to the company instead of posting a public comment.
         if (document.location.pathname.startsWith('/company/')) {
-            const susScore = calculateMessageSusScore(message);
+            const susScore = calculateMessageSusScore(message) + calculateMessageSusScore(author);
 
             if (susScore >= 1) {
                 const confirmation_result = confirm(t('confirm-private-data', 'comments'));
                 if (!confirmation_result) return;
             }
-        }
-        // Names are not allowed to contain email addresses.
-        if (author.includes('@')) {
-            flash(<FlashMessage type="error">{t('no-email-in-name', 'comments')}</FlashMessage>);
-            return;
         }
 
         flash(<FlashMessage type="info">{t('sending', 'comments')}</FlashMessage>);

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -669,7 +669,7 @@
         "rss-link": "Abonniere die Kommentare zu diesem Artikel mit Deinem RSS-/Atom-Feed-Reader.",
         "warning": "Beachte bitte, dass wir ein <em>unabhängiger Datenschutzverein</em> sind und nicht zu dem hier aufgeführten Unternehmen gehören.<br>Solltest Du also Support benötigen oder eine Anfrage stellen wollen, wende Dich bitte direkt an das Unternehmen. Wir können Dir hierbei <strong>nicht</strong> helfen. Danke für Dein Verständnis.",
         "confirm-private-data": "Huch, es sieht so als, als würde Dein Kommentar eventuell persönliche Daten enthalten oder sich auf eine Bestellung beziehen. Bist Du sicher, dass Du die Nachricht als ÖFFENTLICHEN Kommentar absenden möchtest? Kommentare werden NICHT an das Unternehmen gesendet.",
-        "regex-sus-words": "bestellung|bestellen|bestellnummer|bestellnr|fallnummer|trackingnummer|sendungsnummer|IBAN|kontonummer|bankkonto|verwendungszweck|überweisung|ueberweisung|rücksendung|ruecksendung|retoure|transaktion|buchung|reservierung|paket|päckchen|paeckchen|rückruf|rueckruf",
+        "regex-sus-words": "bestellung|bestellen|bestellnummer|bestellnr|fallnummer|trackingnummer|sendungsnummer|transaktionsnummer|kundennummer|kundennr|IBAN|kontonummer|kontonr|bankkonto|verwendungszweck|überweisung|ueberweisung|abbuchung|einzahlung|rückbuchung|rueckbuchung|rücksendung|ruecksendung|retoure|erstattung|vergütung|verguetung|transaktion|buchung|reservierung|paket|päckchen|paeckchen|rückruf|rueckruf",
         "no-email-in-name": "Bitte gib keine E-Mail-Adresse als Namen an. Kommentare werden öffentlich angezeigt und nicht an das Unternehmen gesendet."
     },
     "company-packs": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -668,7 +668,7 @@
         "rss-link": "Subscribe to the comments on this post using your RSS/Atom feed reader.",
         "warning": "Please note that we are an <em>independent non-profit</em> and not affiliated with the company listed here.<br>If you need support or want to send a request, please contact the company directly. We <strong>cannot</strong> help you in such cases. Thanks for your understanding.",
         "confirm-private-data": "Whoops, looks like your comment might contain private data or refer to an order. Do you really want to post this as a PUBLIC comment? Comments will NOT be sent to the company.",
-        "regex-sus-words": "order number|confirmation number|tracking number|IBAN|bank account|payment reference|bank transfer|subscription fee|return address|transaction|booking|reserveration|package|parcel",
+        "regex-sus-words": "order number|confirmation number|tracking number|transfer number|customer number|IBAN|bank account|payment reference|bank transfer|withdrawal|deposit|subscription fee|return address|refund|transaction|booking|reserveration|package|parcel",
         "no-email-in-name": "Please don’t provide an email address in the name field. Comments are posted publicly and will not be sent to the company."
     },
     "company-packs": {


### PR DESCRIPTION
Based on a few comments we have received since the original PR was merged.

Two more changes in this commit:
* Also calculate a "sus score" for the "author" field, we get quite a few comments with message text in that field.
* Accordingly, do the "no email in author" check first.