### PR TITLE
Optimize deploy script by only renaming once

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -18,6 +18,11 @@ languages=(de en fr pt es hr nl cs)
 echo "Fetching data…"
 git clone --depth 1 https://github.com/datenanfragen/data data_tmp
 
+# When developing locally, we need to make sure to remove any old company pages.
+rm -rf content/**/company
+rm -rf content/**/supervisory-authority
+rm -rf static/db
+
 echo "Creating directories…"
 for lang in ${languages[@]}
 do


### PR DESCRIPTION
With more languages and companies being added, our deploy script has been getting slower and slower for a while. That makes sense since we have to copy and rename each record for each language. With currently more than 3,000 companies and 8 languages, that is quite a lot of work.

Today, I happened to notice that the copying of the files is super fast while the renaming takes a long time. Taking a closer look at the script, that shouldn't be too surprising: We're spawning a separate shell for each rename operation, ~24,000 shells in total.

There's a trivial optimization to be had here: Only do the renaming once and _then_ copy the already renamed files. While still not great (since we still spawn ~3,000 shells), that is a huge improvement.

On my machine, the previous version of the deploy script took 56s excluding the "Running Webpack and Hugo…" steps. With this change, it only takes 12s.

And since we're literally just rearranging code, this should also be fine in CI, unlike our earlier tries with GNU parallel.

---

From looking at the code, I'm _reasonably_ sure that this change shouldn't break anything (like the JSONs in `static/db`), but it would be good to have this reviewed carefully.