### PR TITLE
Fixes dependency version for brutusin-json-forms to specific commit hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     },
     "dependencies": {
         "autocomplete.js": "^0.37.0",
-        "brutusin-json-forms": "https://github.com/brutusin/json-forms",
+        "brutusin-json-forms": "https://github.com/brutusin/json-forms#44f27b29ef657f545b8a3d162c2b9c90ef137dbc",
         "cross-dirname": "^0.1.0",
         "deepmerge": "^4.2.2",
         "fast-deep-equal": "^3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3112,7 +3112,7 @@ browserslist@^4.20.2:
     node-releases "^2.0.3"
     picocolors "^1.0.0"
 
-"brutusin-json-forms@https://github.com/brutusin/json-forms":
+"brutusin-json-forms@https://github.com/brutusin/json-forms#44f27b29ef657f545b8a3d162c2b9c90ef137dbc":
   version "0.0.0"
   resolved "https://github.com/brutusin/json-forms#44f27b29ef657f545b8a3d162c2b9c90ef137dbc"
 


### PR DESCRIPTION
While working on https://github.com/datenanfragen/website/pull/1208 I saw that the brutusin-json-forms is not pinned and outdated since 7 years.

This pull request makes a minor update to the `brutusin-json-forms` dependency in `package.json`, pinning it to a specific commit hash for improved stability and reproducibility.

It's slightly better than the default branch on a GitHub repo :)