### PR TITLE
Fixes #1139: Reverse default sort order in RequestList

### DIFF
--- a/cypress/e2e/old-bugs/no-fail-on-invalid-date-in-importmessagemodal.spec.js
+++ b/cypress/e2e/old-bugs/no-fail-on-invalid-date-in-importmessagemodal.spec.js
@@ -8,6 +8,7 @@ describe('ImportMessageModal', () => {
     beforeEach(() => {
         skipOn(isOn('production'));
 
+        cy.clearIndexedDb('Datenanfragen.de');
         cy.visit('/my-requests');
         // TODO: Can this be more elegant?
         // eslint-disable-next-line cypress/no-unnecessary-waiting


### PR DESCRIPTION
I deliberately didn't change the sort order for the exports (CSV and ICS). I think for those, old to new makes more sense.

I've added a prop to RequestList to determine the sort order. In the future, we might want to add a UI toggle for that. But this order seems much more sensible to me.