### PR TITLE
Clearer button labels for actions that publish things

### DIFF
--- a/content/cs/suggest.md
+++ b/content/cs/suggest.md
@@ -24,7 +24,7 @@ Do you have any further comments or notes that we should take into account when 
 <label for="comment" class="sr-only">Additional comments</label>
 <textarea id="comment" class="form-element" rows="5"></textarea>
 
-<button id="submit-suggest-form" class="button button-primary">Submit <span class="icon icon-arrow-right"></span></button><div class="clearfix"></div>
+<button id="submit-suggest-form" class="button button-primary">Publish <span class="icon icon-arrow-right"></span></button><div class="clearfix"></div>
 </div>
 
 By submitting this form, you agree for your contributions to be published in our company database and license them under a [CC0 license](https://creativecommons.org/publicdomain/zero/1.0), which allows anyone to use them without restrictions.

--- a/content/de/suggest.md
+++ b/content/de/suggest.md
@@ -41,7 +41,7 @@ Hast Du weitere Anmerkungen oder Hinweise, die wir bei der Überprüfung Deines 
 <label for="comment" class="sr-only">Zusätzliche Anmerkungen</label>
 <textarea id="comment" class="form-element" rows="5"></textarea>
 
-<button id="submit-suggest-form" class="button button-primary">Absenden <span class="icon icon-arrow-right"></span></button><div class="clearfix"></div>
+<button id="submit-suggest-form" class="button button-primary">Veröffentlichen <span class="icon icon-arrow-right"></span></button><div class="clearfix"></div>
 </div>
 
 

--- a/content/en/suggest.md
+++ b/content/en/suggest.md
@@ -40,7 +40,7 @@ Do you have any further comments or notes that we should take into account when 
 <label for="comment" class="sr-only">Additional comments</label>
 <textarea id="comment" class="form-element" rows="5"></textarea>
 
-<button id="submit-suggest-form" class="button button-primary">Submit <span class="icon icon-arrow-right"></span></button><div class="clearfix"></div>
+<button id="submit-suggest-form" class="button button-primary">Publish <span class="icon icon-arrow-right"></span></button><div class="clearfix"></div>
 </div>
 
 By submitting this form, you agree for your contributions to be published in our company database and license them under a [CC0 license](https://creativecommons.org/publicdomain/zero/1.0), which allows anyone to use them without restrictions.

--- a/content/es/suggest.md
+++ b/content/es/suggest.md
@@ -41,7 +41,7 @@ Si tienes alguna sugerencia que no se puede manejar a través de este formulario
 <label for="comment" class="sr-only">Comentarios adicionales</label>
 <textarea id="comment" class="form-element" rows="5"></textarea>
 
-<button id="submit-suggest-form" class="button button-primary">Enviar <span class="icon icon-arrow-right"></span></button><div class="clearfix"></div>
+<button id="submit-suggest-form" class="button button-primary">Publicar <span class="icon icon-arrow-right"></span></button><div class="clearfix"></div>
 </div>
 
 Al enviar este formulario, aceptas que tus contribuciones se publiquen en nuestra base de datos de empresas y bajo una [licencia CC0](https://creativecommons.org/publicdomain/zero/1.0), lo que permite que cualquiera pueda usarlos sin restricciones.

--- a/content/fr/suggest.md
+++ b/content/fr/suggest.md
@@ -23,7 +23,7 @@ As-tu d'autres commentaires ou remarques à nous faire parvenir concernant l'exa
 <label for="comment" class="sr-only">Commentaires supplémentaires</label>
 <textarea id="comment" class="form-element" rows="5"></textarea>
 
-<button id="submit-suggest-form" class="button button-primary">Proposer <span class="icon icon-arrow-right"></span></button><div class="clearfix"></div>
+<button id="submit-suggest-form" class="button button-primary">Publier <span class="icon icon-arrow-right"></span></button><div class="clearfix"></div>
 </div>
 
 En soumettant ce formulaire, tu acceptes que tes contributions soient publiées dans notre base de données d'entreprises et que tu les concèdes sous [licence CC0](https://creativecommons.org/publicdomain/zero/1.0), qui permet à quiconque de les utiliser sans restriction.

--- a/content/hr/suggest.md
+++ b/content/hr/suggest.md
@@ -40,7 +40,7 @@ Do you have any further comments or notes that we should take into account when 
 <label for="comment" class="sr-only">Additional comments</label>
 <textarea id="comment" class="form-element" rows="5"></textarea>
 
-<button id="submit-suggest-form" class="button button-primary">Pošalji <span class="icon icon-arrow-right"></span></button><div class="clearfix"></div>
+<button id="submit-suggest-form" class="button button-primary">Objavi <span class="icon icon-arrow-right"></span></button><div class="clearfix"></div>
 </div>
 
 Slanjem ovog obrasca pristaješ, da se tvoji prilozi objavljuju u našoj bazi podataka te da se podaci licenciraju pod [CC0 licencom](https://creativecommons.org/publicdomain/zero/1.0), čime se svima omogućuje neograničeno korištenje podataka.

--- a/content/nl/suggest.md
+++ b/content/nl/suggest.md
@@ -22,7 +22,7 @@ Do you have any further comments or notes that we should take into account when 
 <label for="comment" class="sr-only">Additional comments</label>
 <textarea id="comment" class="form-element" rows="5"></textarea>
 
-<button id="submit-suggest-form" class="button button-primary">Submit <span class="icon icon-arrow-right"></span></button><div class="clearfix"></div>
+<button id="submit-suggest-form" class="button button-primary">Publish <span class="icon icon-arrow-right"></span></button><div class="clearfix"></div>
 </div>
 
 By submitting this form, you agree for your contributions to be published in our company database and license them under a [CC0 license](https://creativecommons.org/publicdomain/zero/1.0), which allows anyone to use them without restrictions.

--- a/content/pt/suggest.md
+++ b/content/pt/suggest.md
@@ -22,7 +22,7 @@ Do you have any further comments or notes that we should take into account when 
 <label for="comment" class="sr-only">Additional comments</label>
 <textarea id="comment" class="form-element" rows="5"></textarea>
 
-<button id="submit-suggest-form" class="button button-primary">Submit <span class="icon icon-arrow-right"></span></button><div class="clearfix"></div>
+<button id="submit-suggest-form" class="button button-primary">Publish <span class="icon icon-arrow-right"></span></button><div class="clearfix"></div>
 </div>
 
 By submitting this form, you agree for your contributions to be published in our company database and license them under a [CC0 license](https://creativecommons.org/publicdomain/zero/1.0), which allows anyone to use them without restrictions.

--- a/src/Components/CommentsWidget.tsx
+++ b/src/Components/CommentsWidget.tsx
@@ -305,7 +305,7 @@ export function CommentForm(props: CommentFormProps) {
                     submitComment();
                 }}
                 style="float: right;">
-                <Text id="submit" />
+                <Text id="publish-comment" />
             </button>
             <div className="clearfix" />
         </form>

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -680,7 +680,7 @@
         "comments": "Kommentare",
         "comment": "Kommentar",
         "author": "Autor_in",
-        "submit": "Absenden",
+        "publish-comment": "Kommentar veröffentlichen",
         "sending": "Verschicke Deinen Kommentar…",
         "send-success": "Kommentar erfolgreich abgesendet. Der Kommentar wird erst angezeigt, wenn er von einer Administrator_in überprüft wurde.",
         "send-error": "Fehler beim Absenden des Kommentars. Bitte versuche es später erneut.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -679,7 +679,7 @@
         "comments": "Comments",
         "comment": "Comment",
         "author": "Author",
-        "submit": "Submit",
+        "publish-comment": "Publish comment",
         "sending": "Submitting your comment…",
         "send-success": "Comment sent successfully. It will have to be accepted by an administrator first before it is shown here.",
         "send-error": "An error occurred while sending your comment. Please try again later.",


### PR DESCRIPTION
These should hopefully make it less likely for people to mistake our contribution avenues for contact forms…

via: https://simonwillison.net/2025/Aug/2/wikipedia-save-button/