### PR TITLE
Suggest: Use better slugify

### DIFF
--- a/ATTRIBUTION
+++ b/ATTRIBUTION
@@ -73,6 +73,9 @@ https://github.com/google/roboto
 Spartan MB by Matt Bailey ([OFL 1.1](https://github.com/MattBaileyDesign/Spartan-MB/blob/V-1.006/OFL.txt))
 https://github.com/MattBaileyDesign/Spartan-MB
 
+slugify by Sindre Sorhus ([MIT License](https://github.com/sindresorhus/slugify/blob/main/license))
+https://github.com/sindresorhus/slugify
+
 SpinKit by Tobias Ahlin ([MIT License](https://github.com/tobiasahlin/SpinKit/blob/master/LICENSE))
 https://github.com/tobiasahlin/SpinKit
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "build-sample-letters": "node ./scripts/build-sample-letters/build.js"
     },
     "dependencies": {
+        "@sindresorhus/slugify": "2.2.1",
         "autocomplete.js": "^0.37.0",
         "brutusin-json-forms": "https://github.com/brutusin/json-forms#44f27b29ef657f545b8a3d162c2b9c90ef137dbc",
         "cross-dirname": "^0.1.0",

--- a/src/Utility/common.ts
+++ b/src/Utility/common.ts
@@ -2,6 +2,9 @@ import type { I18nLanguage } from '../types/globals';
 import type { Country } from '../store/app';
 
 // Adapted after: https://gist.github.com/mathewbyrne/1280286
+// We deliberately have both this minimal implementation and @sindresorhus/slugify, because the bundle size of the
+// latter is quite large. Decide on which to use based on how good of a slugify implementation is needed. For example,
+// this one cannot handle non-ASCII characters.
 export const slugify = (text: string) =>
     text
         ?.toString()

--- a/src/suggest-edit.js
+++ b/src/suggest-edit.js
@@ -2,7 +2,7 @@ import { render, Component, Fragment } from 'preact';
 import Modal from './Components/DeprecatedModal';
 import t from 'Utility/i18n';
 import { fetchCompanyDataBySlug } from './Utility/companies';
-import { slugify, domainWithoutTldFromUrl } from './Utility/common';
+import { domainWithoutTldFromUrl } from './Utility/common';
 import { parsePhoneNumberFromString } from 'libphonenumber-js';
 require('brutusin-json-forms');
 /* global brutusin */
@@ -11,6 +11,7 @@ import { submitUrl } from './Utility/suggest';
 import { FlashMessage, flash } from './Components/FlashMessage';
 import { searchClient } from 'Utility/search';
 import equal from 'fast-deep-equal';
+import slugify from '@sindresorhus/slugify';
 let bf;
 let schema;
 let company_data_old;
@@ -268,7 +269,8 @@ document.getElementById('submit-suggest-form').onclick = () => {
     // Do some post-processing on the user-submitted data to make the review easier.
     if (!data.slug) {
         const DOMAIN = domainWithoutTldFromUrl(data.web);
-        data.slug = slugify(DOMAIN ? DOMAIN.replace('www.', '') : data.name);
+        // `decamelize` causes `Abc GmbH` to be turned into `abc-gmb-h`.
+        data.slug = slugify(DOMAIN ? DOMAIN.replace('www.', '') : data.name, { decamelize: false });
     }
     if (!data['relevant-countries']) data['relevant-countries'] = ['all'];
     if (data.phone) data.phone = formatPhoneNumber(data.phone);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,6 +1739,21 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
+"@sindresorhus/slugify@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/slugify/-/slugify-2.2.1.tgz#fa2e2e25d6e1e74a2eeb5e2c37f5ccc516ed2c4b"
+  integrity sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==
+  dependencies:
+    "@sindresorhus/transliterate" "^1.0.0"
+    escape-string-regexp "^5.0.0"
+
+"@sindresorhus/transliterate@^1.0.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/transliterate/-/transliterate-1.6.0.tgz#2309fff65a868047e6d2dd70dec747c5b36a8327"
+  integrity sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==
+  dependencies:
+    escape-string-regexp "^5.0.0"
+
 "@swc/helpers@^0.3.13":
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.3.17.tgz#7c1b91f43c77e2bba99492162a498d465ef253d5"
@@ -5233,6 +5248,11 @@ escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+escape-string-regexp@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
 escodegen@^1.11.1, escodegen@^1.8.0:
   version "1.14.3"


### PR DESCRIPTION
The minimal implementation we used previously for example could not deal with non-ASCII characters and would for example turn umlauts into slashes, which is easy to miss when reviewing.

With this commit, we now use @sindresorhus/slugify with `decamelize` disabled, which matches data-editor.